### PR TITLE
feat: セッション履歴の復元機能 (Issue #1)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -173,7 +173,7 @@ export default function DashboardPage() {
                 {sessions.map((item, idx) => (
                   <Link
                     key={item.id}
-                    href="/chat"
+                    href={`/chat?session=${item.id}`}
                     className="group bg-bg-secondary rounded-[20px] border border-border-light overflow-hidden transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_4px_24px_rgba(26,23,20,.10)] no-underline text-text-primary"
                   >
                     {/* サムネイル */}


### PR DESCRIPTION
## Summary
- ダッシュボードの生成履歴カードにセッションIDをURLパラメータとして付与（`/chat?session=<id>`）
- チャット画面でURLのsessionパラメータを読み取り、DBからメッセージ履歴を取得・表示
- 構成案（Proposal）・フローステップ・店名を自動復元し、途中からチャットを再開可能
- 復元中のローディング表示、入力欄の無効化など復元UXを実装
- Next.js App RouterのuseSearchParamsをSuspenseでラップして対応

## Test plan
- [ ] ダッシュボードからセッションカードをクリックし、チャット画面に遷移することを確認
- [ ] 復元されたチャット画面で過去のメッセージが正しく時系列順に表示されることを確認
- [ ] 構成案がある場合、ProposalカードとPreviewパネルが復元されることを確認
- [ ] 復元後に新しいメッセージを送信してチャットを再開できることを確認
- [ ] `/chat`（パラメータなし）で新規チャットが従来通り開始されることを確認
- [ ] 存在しないセッションIDを指定した場合、新規チャット状態にフォールバックすることを確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)