### PR TITLE
design: AuthLayout共通化 + 認証・設定・管理画面デザインリフレッシュ

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -29,6 +29,11 @@ export default function AdminLayout({
           <span className="text-accent-warm">MenuCraft</span>
           <span className="text-xs px-2 py-0.5 rounded bg-accent-warm text-white font-bold">ADMIN</span>
         </Link>
+        {/* ヘッダー装飾アクセント */}
+        <div className="ml-4 flex items-center gap-1.5 opacity-40">
+          <div className="w-1 h-1 rounded-full bg-accent-gold" />
+          <div className="w-6 h-[1px] bg-gradient-to-r from-accent-gold to-transparent" />
+        </div>
         <div className="flex-1" />
         <Link
           href="/dashboard"
@@ -40,18 +45,34 @@ export default function AdminLayout({
 
       <div className="flex mt-[52px]">
         {/* サイドバー */}
-        <aside className="w-[220px] min-h-[calc(100vh-52px)] bg-bg-secondary border-r border-border-light flex-shrink-0 py-4">
-          <nav className="flex flex-col gap-1 px-3">
+        <aside className="w-[220px] min-h-[calc(100vh-52px)] bg-bg-secondary border-r border-border-light flex-shrink-0 py-4 relative overflow-hidden">
+          {/* サイドバー ブラーサークル（控えめ） */}
+          <div className="absolute bottom-[10%] left-[-20%] w-40 h-40 bg-accent-warm/[.03] rounded-full blur-3xl pointer-events-none" />
+
+          {/* サイドバー下部 ドットパターン */}
+          <div
+            className="absolute bottom-0 left-0 right-0 h-32 pointer-events-none opacity-[.04]"
+            style={{
+              backgroundImage: "radial-gradient(circle, #1A1A1A 1px, transparent 1px)",
+              backgroundSize: "20px 20px",
+            }}
+          />
+
+          <nav className="flex flex-col gap-1 px-3 relative z-10">
             {NAV_ITEMS.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
-                className={`flex items-center gap-2.5 px-3 py-2.5 rounded-[8px] text-sm no-underline transition-all duration-200 ${
+                className={`flex items-center gap-2.5 px-3 py-2.5 rounded-[8px] text-sm no-underline transition-all duration-200 relative ${
                   isActive(item.href)
                     ? "bg-bg-primary text-text-primary font-medium shadow-sm"
                     : "text-text-secondary hover:bg-bg-primary hover:text-text-primary"
                 }`}
               >
+                {/* アクティブ時の左端アクセントバー */}
+                {isActive(item.href) && (
+                  <div className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-5 bg-accent-warm rounded-full" />
+                )}
                 <span className="text-base">{item.icon}</span>
                 {item.label}
               </Link>

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import AuthLayout from "@/components/auth/AuthLayout";
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
@@ -14,87 +15,53 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-bg-primary px-4">
-      <div className="fixed inset-0 pointer-events-none" style={{
-        background: "radial-gradient(ellipse at 20% 50%, rgba(196,113,59,.06), transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(212,168,83,.06), transparent 50%)"
-      }} />
+    <AuthLayout
+      title={submitted ? "メールを送信しました" : "パスワードをリセット"}
+      subtitle={submitted ? undefined : "登録メールアドレスにリセットリンクをお送りします"}
+    >
+      {!submitted ? (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
+              メールアドレス
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="example@email.com"
+              required
+              className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
+            />
+          </div>
 
-      <div className="w-full max-w-[420px] relative z-10">
-        {/* ロゴ */}
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center gap-2 no-underline">
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="#D4A853" strokeWidth="2" />
-              <path d="M8 14s1.5 2 4 2 4-2 4-2" stroke="#D4A853" strokeWidth="2" strokeLinecap="round" />
-              <circle cx="9" cy="10" r="1" fill="#D4A853" />
-              <circle cx="15" cy="10" r="1" fill="#D4A853" />
-            </svg>
-            <span className="font-[family-name:var(--font-playfair)] text-accent-gold text-xl font-bold tracking-wide">
-              MenuCraft AI
-            </span>
-          </Link>
-        </div>
-
-        {/* カード */}
-        <div className="bg-bg-secondary rounded-[20px] border border-border-light p-8 shadow-[0_4px_24px_rgba(26,23,20,.10)]">
-          {!submitted ? (
-            <>
-              <h1 className="font-[family-name:var(--font-playfair)] text-2xl font-bold text-center mb-2">
-                パスワードをリセット
-              </h1>
-              <p className="text-text-secondary text-sm text-center mb-8">
-                登録メールアドレスにリセットリンクをお送りします
-              </p>
-
-              <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-                <div>
-                  <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
-                    メールアドレス
-                  </label>
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="example@email.com"
-                    required
-                    className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
-                  />
-                </div>
-
-                <button
-                  type="submit"
-                  className="w-full py-3.5 rounded-[28px] bg-bg-dark text-text-inverse text-sm font-semibold transition-all duration-300 hover:shadow-[0_12px_40px_rgba(26,23,20,.14)] hover:-translate-y-0.5 mt-2 cursor-pointer"
-                >
-                  リセットリンクを送信 →
-                </button>
-              </form>
-            </>
-          ) : (
-            <div className="text-center py-4">
-              <div className="text-4xl mb-4">✉️</div>
-              <h2 className="font-[family-name:var(--font-playfair)] text-xl font-bold mb-2">
-                メールを送信しました
-              </h2>
-              <p className="text-text-secondary text-sm mb-6">
-                <strong>{email}</strong> にパスワードリセットのリンクを送信しました。メールをご確認ください。
-              </p>
-              <p className="text-text-muted text-xs">
-                ※ 現在デモ版のため、実際のメール送信は行われません
-              </p>
-            </div>
-          )}
-        </div>
-
-        {/* 戻るリンク */}
-        <p className="text-center text-sm text-text-secondary mt-6">
-          <Link
-            href="/login"
-            className="text-accent-warm font-semibold hover:text-accent-warm-hover transition-colors no-underline"
+          <button
+            type="submit"
+            className="w-full py-3.5 rounded-[28px] bg-bg-dark text-text-inverse text-sm font-semibold transition-all duration-300 hover:shadow-[0_12px_40px_rgba(26,23,20,.14)] hover:-translate-y-0.5 mt-2 cursor-pointer"
           >
-            ← ログインに戻る
-          </Link>
-        </p>
-      </div>
-    </div>
+            リセットリンクを送信 →
+          </button>
+        </form>
+      ) : (
+        <div className="text-center py-4">
+          <div className="text-4xl mb-4">✉️</div>
+          <p className="text-text-secondary text-sm mb-6">
+            <strong>{email}</strong> にパスワードリセットのリンクを送信しました。メールをご確認ください。
+          </p>
+          <p className="text-text-muted text-xs">
+            ※ 現在デモ版のため、実際のメール送信は行われません
+          </p>
+        </div>
+      )}
+
+      <p className="text-center text-sm text-text-secondary mt-6">
+        <Link
+          href="/login"
+          className="text-accent-warm font-semibold hover:text-accent-warm-hover transition-colors no-underline"
+        >
+          ← ログインに戻る
+        </Link>
+      </p>
+    </AuthLayout>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import { signIn } from "next-auth/react";
+import AuthLayout from "@/components/auth/AuthLayout";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -30,118 +31,79 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-bg-primary px-4">
-      {/* 背景グラデーション */}
-      <div className="fixed inset-0 pointer-events-none" style={{
-        background: "radial-gradient(ellipse at 20% 50%, rgba(196,113,59,.06), transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(212,168,83,.06), transparent 50%), radial-gradient(ellipse at 50% 80%, rgba(123,138,100,.04), transparent 40%)"
-      }} />
+    <AuthLayout title="おかえりなさい" subtitle="アカウントにログインしてください">
+      {/* デモ情報（デモモード時のみ表示） */}
+      {process.env.NEXT_PUBLIC_DEMO_MODE === "true" && (
+        <div className="mb-6 p-3 rounded-[8px] bg-[rgba(123,138,100,.1)] border border-[rgba(123,138,100,.2)]">
+          <div className="text-xs font-semibold text-accent-olive mb-1">デモアカウント</div>
+          <div className="text-xs text-text-secondary">
+            Email: <code className="bg-bg-tag px-1 rounded">demo@menucraft.jp</code><br/>
+            Pass: <code className="bg-bg-tag px-1 rounded">demo1234</code>
+          </div>
+        </div>
+      )}
 
-      <div className="w-full max-w-[420px] relative z-10">
-        {/* ロゴ */}
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center gap-2 no-underline">
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="#D4A853" strokeWidth="2" />
-              <path d="M8 14s1.5 2 4 2 4-2 4-2" stroke="#D4A853" strokeWidth="2" strokeLinecap="round" />
-              <circle cx="9" cy="10" r="1" fill="#D4A853" />
-              <circle cx="15" cy="10" r="1" fill="#D4A853" />
-            </svg>
-            <span className="font-[family-name:var(--font-playfair)] text-accent-gold text-xl font-bold tracking-wide">
-              MenuCraft AI
-            </span>
-          </Link>
+      {error && (
+        <div className="mb-4 p-3 rounded-[8px] bg-red-50 border border-red-200 text-red-600 text-sm">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
+            メールアドレス
+          </label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="example@email.com"
+            required
+            className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
+          />
         </div>
 
-        {/* カード */}
-        <div className="bg-bg-secondary rounded-[20px] border border-border-light p-8 shadow-[0_4px_24px_rgba(26,23,20,.10)]">
-          <h1 className="font-[family-name:var(--font-playfair)] text-2xl font-bold text-center mb-2">
-            おかえりなさい
-          </h1>
-          <p className="text-text-secondary text-sm text-center mb-8">
-            アカウントにログインしてください
-          </p>
-
-          {/* デモ情報（デモモード時のみ表示） */}
-          {process.env.NEXT_PUBLIC_DEMO_MODE === "true" && (
-            <div className="mb-6 p-3 rounded-[8px] bg-[rgba(123,138,100,.1)] border border-[rgba(123,138,100,.2)]">
-              <div className="text-xs font-semibold text-accent-olive mb-1">デモアカウント</div>
-              <div className="text-xs text-text-secondary">
-                Email: <code className="bg-bg-tag px-1 rounded">demo@menucraft.jp</code><br/>
-                Pass: <code className="bg-bg-tag px-1 rounded">demo1234</code>
-              </div>
-            </div>
-          )}
-
-          {/* エラー表示 */}
-          {error && (
-            <div className="mb-4 p-3 rounded-[8px] bg-red-50 border border-red-200 text-red-600 text-sm">
-              {error}
-            </div>
-          )}
-
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            {/* メールアドレス */}
-            <div>
-              <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
-                メールアドレス
-              </label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="example@email.com"
-                required
-                className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
-              />
-            </div>
-
-            {/* パスワード */}
-            <div>
-              <div className="flex items-center justify-between mb-1.5">
-                <label className="block text-xs font-medium text-text-secondary tracking-wide">
-                  パスワード
-                </label>
-                <Link
-                  href="/forgot-password"
-                  className="text-xs text-accent-warm hover:text-accent-warm-hover transition-colors no-underline"
-                >
-                  パスワードをお忘れですか？
-                </Link>
-              </div>
-              <input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="パスワードを入力"
-                required
-                className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
-              />
-            </div>
-
-            {/* ログインボタン */}
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="w-full py-3.5 rounded-[28px] bg-bg-dark text-text-inverse text-sm font-semibold transition-all duration-300 hover:shadow-[0_12px_40px_rgba(26,23,20,.14)] hover:-translate-y-0.5 disabled:opacity-60 disabled:cursor-not-allowed mt-2 cursor-pointer"
+        <div>
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="block text-xs font-medium text-text-secondary tracking-wide">
+              パスワード
+            </label>
+            <Link
+              href="/forgot-password"
+              className="text-xs text-accent-warm hover:text-accent-warm-hover transition-colors no-underline"
             >
-              {isLoading ? "ログイン中..." : "ログイン →"}
-            </button>
-          </form>
-
-          {/* OAuth連携（Google等）はPhase 3で実装予定 */}
+              パスワードをお忘れですか？
+            </Link>
+          </div>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="パスワードを入力"
+            required
+            className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
+          />
         </div>
 
-        {/* サインアップリンク */}
-        <p className="text-center text-sm text-text-secondary mt-6">
-          アカウントをお持ちでないですか？{" "}
-          <Link
-            href="/signup"
-            className="text-accent-warm font-semibold hover:text-accent-warm-hover transition-colors no-underline"
-          >
-            無料で登録
-          </Link>
-        </p>
-      </div>
-    </div>
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full py-3.5 rounded-[28px] bg-bg-dark text-text-inverse text-sm font-semibold transition-all duration-300 hover:shadow-[0_12px_40px_rgba(26,23,20,.14)] hover:-translate-y-0.5 disabled:opacity-60 disabled:cursor-not-allowed mt-2 cursor-pointer"
+        >
+          {isLoading ? "ログイン中..." : "ログイン →"}
+        </button>
+      </form>
+
+      <p className="text-center text-sm text-text-secondary mt-6">
+        アカウントをお持ちでないですか？{" "}
+        <Link
+          href="/signup"
+          className="text-accent-warm font-semibold hover:text-accent-warm-hover transition-colors no-underline"
+        >
+          無料で登録
+        </Link>
+      </p>
+    </AuthLayout>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -69,14 +69,31 @@ export default function SettingsPage() {
   return (
     <>
       <Header activeTab="settings" />
-      <main className="mt-[56px] min-h-[calc(100vh-56px)] bg-bg-primary">
-        <div className="max-w-[640px] mx-auto px-6 sm:px-10 py-10">
-          <h1 className="font-[family-name:var(--font-playfair)] text-[28px] font-bold mb-2">
-            アカウント設定
-          </h1>
-          <p className="text-text-secondary text-sm mb-8">
-            プロフィールとプランの管理
-          </p>
+      <main className="mt-[56px] min-h-[calc(100vh-56px)] bg-bg-primary relative overflow-hidden">
+        {/* 背景ブラーサークル */}
+        <div className="absolute top-[5%] left-[3%] w-72 h-72 bg-accent-warm/[.04] rounded-full blur-3xl pointer-events-none" />
+        <div className="absolute top-[40%] right-[5%] w-56 h-56 bg-accent-gold/[.05] rounded-full blur-3xl pointer-events-none" />
+        <div className="absolute bottom-[10%] left-[12%] w-48 h-48 bg-accent-olive/[.04] rounded-full blur-3xl pointer-events-none" />
+
+        <div className="max-w-[640px] mx-auto px-6 sm:px-10 py-10 relative z-10">
+          {/* ヘッダー */}
+          <div className="mb-8 animate-fade-in-up">
+            <span className="inline-block text-xs font-semibold text-accent-warm uppercase tracking-[2px] mb-2">
+              Account Settings
+            </span>
+            <h1 className="font-[family-name:var(--font-playfair)] text-[28px] font-bold mb-2">
+              アカウント設定
+            </h1>
+            <p className="text-text-secondary text-sm">
+              プロフィールとプランの管理
+            </p>
+            {/* 装飾ライン */}
+            <div className="flex items-center gap-2 mt-3">
+              <div className="w-8 h-[2px] bg-accent-warm/30 rounded-full" />
+              <div className="w-2 h-2 rounded-full bg-accent-warm/40" />
+              <div className="w-8 h-[2px] bg-accent-warm/30 rounded-full" />
+            </div>
+          </div>
 
           {loading ? (
             <div className="space-y-4">
@@ -86,28 +103,26 @@ export default function SettingsPage() {
             </div>
           ) : (
             <div className="space-y-6">
-              {/* 成功メッセージ */}
               {message && (
-                <div className="p-3 rounded-[8px] bg-accent-olive/10 border border-accent-olive/20 text-accent-olive text-sm">
+                <div className="p-3 rounded-[8px] bg-accent-olive/10 border border-accent-olive/20 text-accent-olive text-sm animate-fade-in-up">
                   {message}
                 </div>
               )}
 
-              {/* エラーメッセージ */}
               {error && (
-                <div className="p-3 rounded-[8px] bg-red-50 border border-red-200 text-red-600 text-sm">
+                <div className="p-3 rounded-[8px] bg-red-50 border border-red-200 text-red-600 text-sm animate-fade-in-up">
                   {error}
                 </div>
               )}
 
               {/* プロフィール情報 */}
-              <div className="bg-bg-secondary rounded-[20px] border border-border-light p-6">
+              <div className="bg-bg-secondary rounded-[20px] border border-border-light p-6 relative overflow-hidden animate-fade-in-up" style={{ animationDelay: "0.1s" }}>
+                <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-accent-warm via-accent-gold to-transparent" />
                 <h2 className="text-[11px] font-semibold text-accent-warm uppercase tracking-[1px] mb-5">
                   プロフィール
                 </h2>
 
                 <div className="space-y-4">
-                  {/* 店舗名 */}
                   <div>
                     <label className="block text-xs font-medium text-text-secondary mb-1.5">
                       店舗名 / ユーザー名
@@ -120,7 +135,6 @@ export default function SettingsPage() {
                     />
                   </div>
 
-                  {/* メールアドレス（読み取り専用） */}
                   <div>
                     <label className="block text-xs font-medium text-text-secondary mb-1.5">
                       メールアドレス
@@ -136,7 +150,6 @@ export default function SettingsPage() {
                     </p>
                   </div>
 
-                  {/* 登録日 */}
                   <div>
                     <label className="block text-xs font-medium text-text-secondary mb-1.5">
                       登録日
@@ -153,7 +166,6 @@ export default function SettingsPage() {
                   </div>
                 </div>
 
-                {/* 保存ボタン */}
                 <button
                   onClick={handleSave}
                   disabled={saving || name === user?.name}
@@ -164,7 +176,8 @@ export default function SettingsPage() {
               </div>
 
               {/* プラン情報 */}
-              <div className="bg-bg-secondary rounded-[20px] border border-border-light p-6">
+              <div className="bg-bg-secondary rounded-[20px] border border-border-light p-6 relative overflow-hidden animate-fade-in-up" style={{ animationDelay: "0.2s" }}>
+                <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-accent-gold via-accent-olive to-transparent" />
                 <h2 className="text-[11px] font-semibold text-accent-warm uppercase tracking-[1px] mb-5">
                   プラン
                 </h2>
@@ -188,7 +201,8 @@ export default function SettingsPage() {
               </div>
 
               {/* パスワード変更 */}
-              <div className="bg-bg-secondary rounded-[20px] border border-border-light p-6">
+              <div className="bg-bg-secondary rounded-[20px] border border-border-light p-6 relative overflow-hidden animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
+                <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-accent-olive via-accent-warm to-transparent" />
                 <h2 className="text-[11px] font-semibold text-accent-warm uppercase tracking-[1px] mb-5">
                   セキュリティ
                 </h2>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import { signIn } from "next-auth/react";
+import AuthLayout from "@/components/auth/AuthLayout";
 
 export default function SignupPage() {
   const [shopName, setShopName] = useState("");
@@ -20,7 +21,6 @@ export default function SignupPage() {
     setError("");
 
     try {
-      // 1. ユーザー登録API呼び出し
       const res = await fetch("/api/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -35,7 +35,6 @@ export default function SignupPage() {
         return;
       }
 
-      // 2. 登録成功 → 自動ログイン
       const signInResult = await signIn("credentials", {
         email,
         password,
@@ -43,13 +42,11 @@ export default function SignupPage() {
       });
 
       if (signInResult?.error) {
-        // 登録は成功したがログインに失敗（稀なケース）
         setError("アカウントは作成されました。ログインページからログインしてください。");
         setIsLoading(false);
         return;
       }
 
-      // 3. ダッシュボードへリダイレクト
       window.location.href = "/dashboard";
     } catch {
       setError("通信エラーが発生しました。もう一度お試しください。");
@@ -58,134 +55,93 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-bg-primary px-4">
-      {/* 背景グラデーション */}
-      <div className="fixed inset-0 pointer-events-none" style={{
-        background: "radial-gradient(ellipse at 20% 50%, rgba(196,113,59,.06), transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(212,168,83,.06), transparent 50%), radial-gradient(ellipse at 50% 80%, rgba(123,138,100,.04), transparent 40%)"
-      }} />
+    <AuthLayout title="無料で始めましょう" subtitle="30秒で登録完了。クレジットカード不要です。">
+      {error && (
+        <div className="mb-4 p-3 rounded-[8px] bg-red-50 border border-red-200 text-red-600 text-sm">
+          {error}
+        </div>
+      )}
 
-      <div className="w-full max-w-[420px] relative z-10">
-        {/* ロゴ */}
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center gap-2 no-underline">
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="#D4A853" strokeWidth="2" />
-              <path d="M8 14s1.5 2 4 2 4-2 4-2" stroke="#D4A853" strokeWidth="2" strokeLinecap="round" />
-              <circle cx="9" cy="10" r="1" fill="#D4A853" />
-              <circle cx="15" cy="10" r="1" fill="#D4A853" />
-            </svg>
-            <span className="font-[family-name:var(--font-playfair)] text-accent-gold text-xl font-bold tracking-wide">
-              MenuCraft AI
-            </span>
-          </Link>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
+            店舗名
+          </label>
+          <input
+            type="text"
+            value={shopName}
+            onChange={(e) => setShopName(e.target.value)}
+            placeholder="さくらカフェ"
+            required
+            className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
+          />
         </div>
 
-        {/* カード */}
-        <div className="bg-bg-secondary rounded-[20px] border border-border-light p-8 shadow-[0_4px_24px_rgba(26,23,20,.10)]">
-          <h1 className="font-[family-name:var(--font-playfair)] text-2xl font-bold text-center mb-2">
-            無料で始めましょう
-          </h1>
-          <p className="text-text-secondary text-sm text-center mb-8">
-            30秒で登録完了。クレジットカード不要です。
+        <div>
+          <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
+            メールアドレス
+          </label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="example@email.com"
+            required
+            className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
+            パスワード
+          </label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="8文字以上で設定"
+            required
+            minLength={8}
+            className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
+          />
+          <p className="text-xs text-text-muted mt-1.5">
+            英数字を含む8文字以上
           </p>
-
-          {/* エラー表示 */}
-          {error && (
-            <div className="mb-4 p-3 rounded-[8px] bg-red-50 border border-red-200 text-red-600 text-sm">
-              {error}
-            </div>
-          )}
-
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            {/* 店舗名 */}
-            <div>
-              <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
-                店舗名
-              </label>
-              <input
-                type="text"
-                value={shopName}
-                onChange={(e) => setShopName(e.target.value)}
-                placeholder="さくらカフェ"
-                required
-                className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
-              />
-            </div>
-
-            {/* メールアドレス */}
-            <div>
-              <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
-                メールアドレス
-              </label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="example@email.com"
-                required
-                className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
-              />
-            </div>
-
-            {/* パスワード */}
-            <div>
-              <label className="block text-xs font-medium text-text-secondary mb-1.5 tracking-wide">
-                パスワード
-              </label>
-              <input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="8文字以上で設定"
-                required
-                minLength={8}
-                className="w-full px-4 py-3 rounded-[8px] border border-border-light bg-bg-primary text-text-primary text-sm outline-none transition-all duration-300 focus:border-accent-warm focus:shadow-[0_0_0_3px_rgba(196,113,59,.12)] placeholder:text-text-muted"
-              />
-              <p className="text-xs text-text-muted mt-1.5">
-                英数字を含む8文字以上
-              </p>
-            </div>
-
-            {/* 利用規約同意 */}
-            <label className="flex items-start gap-2.5 cursor-pointer mt-1">
-              <input
-                type="checkbox"
-                checked={agreed}
-                onChange={(e) => setAgreed(e.target.checked)}
-                className="mt-0.5 w-4 h-4 accent-accent-warm cursor-pointer"
-              />
-              <span className="text-xs text-text-secondary leading-relaxed">
-                <Link href="/terms" className="text-accent-warm no-underline hover:text-accent-warm-hover">利用規約</Link>
-                {" "}と{" "}
-                <Link href="/privacy" className="text-accent-warm no-underline hover:text-accent-warm-hover">プライバシーポリシー</Link>
-                {" "}に同意します
-              </span>
-            </label>
-
-            {/* 登録ボタン */}
-            <button
-              type="submit"
-              disabled={isLoading || !agreed}
-              className="w-full py-3.5 rounded-[28px] bg-accent-warm text-white text-sm font-semibold transition-all duration-300 hover:bg-accent-warm-hover hover:-translate-y-0.5 disabled:opacity-60 disabled:cursor-not-allowed mt-1 cursor-pointer"
-            >
-              {isLoading ? "登録中..." : "無料アカウントを作成 →"}
-            </button>
-          </form>
-
-          {/* OAuth連携（Google等）はPhase 3で実装予定 */}
         </div>
 
-        {/* ログインリンク */}
-        <p className="text-center text-sm text-text-secondary mt-6">
-          すでにアカウントをお持ちですか？{" "}
-          <Link
-            href="/login"
-            className="text-accent-warm font-semibold hover:text-accent-warm-hover transition-colors no-underline"
-          >
-            ログイン
-          </Link>
-        </p>
-      </div>
-    </div>
+        <label className="flex items-start gap-2.5 cursor-pointer mt-1">
+          <input
+            type="checkbox"
+            checked={agreed}
+            onChange={(e) => setAgreed(e.target.checked)}
+            className="mt-0.5 w-4 h-4 accent-accent-warm cursor-pointer"
+          />
+          <span className="text-xs text-text-secondary leading-relaxed">
+            <Link href="/terms" className="text-accent-warm no-underline hover:text-accent-warm-hover">利用規約</Link>
+            {" "}と{" "}
+            <Link href="/privacy" className="text-accent-warm no-underline hover:text-accent-warm-hover">プライバシーポリシー</Link>
+            {" "}に同意します
+          </span>
+        </label>
+
+        <button
+          type="submit"
+          disabled={isLoading || !agreed}
+          className="w-full py-3.5 rounded-[28px] bg-accent-warm text-white text-sm font-semibold transition-all duration-300 hover:bg-accent-warm-hover hover:-translate-y-0.5 disabled:opacity-60 disabled:cursor-not-allowed mt-1 cursor-pointer"
+        >
+          {isLoading ? "登録中..." : "無料アカウントを作成 →"}
+        </button>
+      </form>
+
+      <p className="text-center text-sm text-text-secondary mt-6">
+        すでにアカウントをお持ちですか？{" "}
+        <Link
+          href="/login"
+          className="text-accent-warm font-semibold hover:text-accent-warm-hover transition-colors no-underline"
+        >
+          ログイン
+        </Link>
+      </p>
+    </AuthLayout>
   );
 }

--- a/src/components/auth/AuthLayout.tsx
+++ b/src/components/auth/AuthLayout.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+
+export default function AuthLayout({
+  children,
+  title,
+  subtitle,
+}: {
+  children: React.ReactNode;
+  title: string;
+  subtitle?: string;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-bg-primary px-4 relative overflow-hidden">
+      {/* 背景ブラーサークル */}
+      <div className="absolute top-[10%] left-[5%] w-72 h-72 bg-accent-warm/[.05] rounded-full blur-3xl pointer-events-none" />
+      <div className="absolute top-[60%] right-[8%] w-56 h-56 bg-accent-gold/[.06] rounded-full blur-3xl pointer-events-none" />
+      <div className="absolute bottom-[5%] left-[15%] w-48 h-48 bg-accent-olive/[.04] rounded-full blur-3xl pointer-events-none" />
+
+      {/* ドットパターンオーバーレイ */}
+      <div
+        className="fixed inset-0 pointer-events-none opacity-[.03]"
+        style={{
+          backgroundImage: "radial-gradient(circle, #1A1A1A 1px, transparent 1px)",
+          backgroundSize: "20px 20px",
+        }}
+      />
+
+      <div className="w-full max-w-[420px] relative z-10 animate-fade-in-up">
+        {/* ロゴ */}
+        <div className="text-center mb-8">
+          <Link href="/" className="inline-flex items-center gap-2 no-underline">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
+              <circle cx="12" cy="12" r="10" stroke="#D4A853" strokeWidth="2" />
+              <path d="M8 14s1.5 2 4 2 4-2 4-2" stroke="#D4A853" strokeWidth="2" strokeLinecap="round" />
+              <circle cx="9" cy="10" r="1" fill="#D4A853" />
+              <circle cx="15" cy="10" r="1" fill="#D4A853" />
+            </svg>
+            <span className="font-[family-name:var(--font-playfair)] text-accent-gold text-xl font-bold tracking-wide">
+              MenuCraft AI
+            </span>
+          </Link>
+        </div>
+
+        {/* カード */}
+        <div className="bg-bg-secondary rounded-[20px] border border-border-light p-8 shadow-[0_4px_24px_rgba(26,23,20,.10)] relative overflow-hidden">
+          {/* アクセントバー */}
+          <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-accent-warm via-accent-gold to-accent-olive" />
+
+          <h1 className="font-[family-name:var(--font-playfair)] text-2xl font-bold text-center mb-2">
+            {title}
+          </h1>
+          {subtitle && (
+            <p className="text-text-secondary text-sm text-center mb-8">
+              {subtitle}
+            </p>
+          )}
+
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **AuthLayout共通コンポーネント作成** — ブラーサークル背景、ドットパターン、ロゴ、カード枠（アクセントバー付き）、fadeInUpアニメーションを共通化
- **認証3ページ簡素化** — login(147→109行), signup(191→147行), forgot-password(100→67行) をAuthLayoutでラップし重複削除
- **設定ページ** — ブラーサークル背景、英語ラベル"Account Settings"、装飾ライン、カードアクセントバー、staggered fadeInUp追加
- **管理画面レイアウト** — サイドバーにブラーサークル・ドットパターン、アクティブナビにアクセントバー(w-[3px])、ヘッダー装飾追加

## Test plan
- [ ] login/signup/forgot-password: 見た目がPhase A-Cパターンに統一、入力・送信・エラー表示が正常動作
- [ ] settings: ブラーサークル・アクセントバー・装飾が追加、プロフィール更新が正常動作
- [ ] admin layout: サイドバーにデザインパターン追加、各管理ページのナビゲーション正常
- [ ] `npm run build` — TypeScriptエラーなし
- [ ] `npx eslint src/` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)