### PR TITLE
feat: チャット画像アップロード機能実装（📎ボタン + Geminiマルチモーダル対応）

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -49,7 +49,7 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json();
-    const { messages, sessionId } = body;
+    const { messages, sessionId, imageBase64, imageMimeType } = body;
 
     if (!Array.isArray(messages) || messages.length === 0) {
       return NextResponse.json(
@@ -87,7 +87,19 @@ export async function POST(req: NextRequest) {
     const userContent = typeof lastMessage.content === "string"
       ? lastMessage.content.slice(0, 1000)
       : "";
-    const response = await chat.sendMessage({ message: userContent });
+
+    // 画像付きメッセージの場合、inlineDataとして送信
+    let response;
+    if (imageBase64 && imageMimeType) {
+      response = await chat.sendMessage({
+        message: [
+          { text: userContent },
+          { inlineData: { mimeType: imageMimeType, data: imageBase64 } },
+        ],
+      });
+    } else {
+      response = await chat.sendMessage({ message: userContent });
+    }
     const durationMs = Date.now() - startTime;
     const reply = response.text ?? "";
 

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -101,12 +101,20 @@ export default function ChatMessage({
         {/* 画像アップロード */}
         {msg.image && (
           <div className="mt-2.5 rounded-[12px] overflow-hidden border border-border-light max-w-[240px]">
-            <div
-              className="h-[140px] flex items-center justify-center text-6xl"
-              style={{ background: msg.image.bgColor }}
-            >
-              {msg.image.emoji}
-            </div>
+            {msg.image.publicUrl ? (
+              <img
+                src={msg.image.publicUrl}
+                alt={msg.image.fileName}
+                className="max-w-[240px] max-h-[200px] object-cover"
+              />
+            ) : (
+              <div
+                className="h-[140px] flex items-center justify-center text-6xl"
+                style={{ background: msg.image.bgColor }}
+              >
+                {msg.image.emoji}
+              </div>
+            )}
             <div className="px-3 py-2 bg-bg-primary text-[11px] text-text-muted flex justify-between">
               <span>{msg.image.fileName}</span>
               <span>{msg.image.fileSize}</span>

--- a/src/hooks/chat/types.ts
+++ b/src/hooks/chat/types.ts
@@ -20,7 +20,7 @@ export interface UseChatSessionReturn {
   restoredShopName: string | null;
 
   // ハンドラー
-  handleSend: (text: string) => Promise<void>;
+  handleSend: (text: string, image?: { base64: string; mimeType: string; fileName: string }) => Promise<void>;
   handleQuickReply: (reply: string) => void;
   handleApproveProposal: () => void;
   handleReviseProposal: () => void;

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -86,13 +86,13 @@ export function useChatSession(
 
   // --- ハンドラー ---
 
-  const handleSend = async (text: string) => {
+  const handleSend = async (text: string, image?: { base64: string; mimeType: string; fileName: string }) => {
     const sid = await ensureSession();
     await sendMessage(text, messages, sid, {
       setMessages,
       setIsTyping,
       setCurrentProposal,
-    });
+    }, image);
   };
 
   const handleQuickReply = (reply: string) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,6 +21,9 @@ export interface MessageImage {
   fileName: string;
   fileSize: string;
   bgColor: string;
+  storagePath?: string;
+  publicUrl?: string;
+  mimeType?: string;
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary
- **ChatInput**: 📎ボタンでファイル選択 → プレビューサムネイル表示 → 取消可能 → 送信（10MBサイズ上限、base64変換）
- **画像アップロードフロー**: `/api/upload-image`経由でSupabase Storageに保存 → publicUrl生成 → ユーザーメッセージに画像データ付与
- **Gemini APIマルチモーダル対応**: `/api/chat`が`imageBase64`/`imageMimeType`を受け付け、`inlineData`形式でGeminiに送信
- **ChatMessage実画像表示**: `publicUrl`がある場合は`<img>`で実画像表示、なければ従来のemojiフォールバック
- **型定義拡張**: `MessageImage`に`storagePath`/`publicUrl`/`mimeType`追加、`handleSend`シグネチャを`(text, image?)`に拡張

## Test plan
- [ ] 📎ボタン → 画像選択 → プレビュー表示 → 取消可能
- [ ] 画像付きメッセージ送信 → Supabase Storageに保存確認
- [ ] ChatMessageに実画像が表示される
- [ ] Geminiが画像を認識した応答を返す（例: "この料理は〜に見えます"）
- [ ] テキストのみの送信が従来通り動作する（既存機能の退行なし）
- [ ] セッション復元時に画像付きメッセージが正しく表示される
- [ ] `npm run build` — TypeScriptエラーなし
- [ ] `npx eslint src/` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)