### PR TITLE
feat: 画像タイプタグ付け — 店舗写真/参考イメージの使い分け

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -2,10 +2,13 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 
+export type ImageType = "shop_photo" | "reference";
+
 export interface ImageAttachment {
   base64: string;
   mimeType: string;
   fileName: string;
+  imageType?: ImageType;
 }
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
@@ -22,6 +25,7 @@ export default function ChatInput({
     dataUrl: string;
     attachment: ImageAttachment;
   } | null>(null);
+  const [imageType, setImageType] = useState<ImageType>("shop_photo");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -72,6 +76,7 @@ export default function ChatInput({
 
   const clearImage = () => {
     setImagePreview(null);
+    setImageType("shop_photo");
   };
 
   const handleSubmit = () => {
@@ -79,9 +84,13 @@ export default function ChatInput({
     const trimmed = value.trim();
     if (!trimmed && !imagePreview) return;
 
-    onSend(trimmed || "(画像を送信しました)", imagePreview?.attachment);
+    const attachment = imagePreview?.attachment
+      ? { ...imagePreview.attachment, imageType }
+      : undefined;
+    onSend(trimmed || "(画像を送信しました)", attachment);
     setValue("");
     setImagePreview(null);
+    setImageType("shop_photo");
     setTimeout(() => {
       textareaRef.current?.focus();
     }, 0);
@@ -99,23 +108,50 @@ export default function ChatInput({
     <div className="px-4 md:px-7 py-3 md:py-4 border-t border-border-light bg-bg-secondary flex-shrink-0">
       {/* 画像プレビュー */}
       {imagePreview && (
-        <div className="mb-2 flex items-center gap-2">
-          <div className="relative inline-block">
-            <img
-              src={imagePreview.dataUrl}
-              alt={imagePreview.attachment.fileName}
-              className="h-16 w-16 object-cover rounded-[8px] border border-border-light"
-            />
+        <div className="mb-2">
+          <div className="flex items-center gap-2">
+            <div className="relative inline-block">
+              <img
+                src={imagePreview.dataUrl}
+                alt={imagePreview.attachment.fileName}
+                className="h-16 w-16 object-cover rounded-[8px] border border-border-light"
+              />
+              <button
+                onClick={clearImage}
+                className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-bg-dark text-white text-xs flex items-center justify-center cursor-pointer border-none hover:bg-red-500 transition-colors"
+              >
+                ×
+              </button>
+            </div>
+            <span className="text-xs text-text-muted truncate max-w-[200px]">
+              {imagePreview.attachment.fileName}
+            </span>
+          </div>
+          {/* 画像タイプ選択チップ */}
+          <div className="flex gap-2 mt-2">
             <button
-              onClick={clearImage}
-              className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-bg-dark text-white text-xs flex items-center justify-center cursor-pointer border-none hover:bg-red-500 transition-colors"
+              type="button"
+              onClick={() => setImageType("shop_photo")}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-all duration-200 border ${
+                imageType === "shop_photo"
+                  ? "bg-accent-warm text-white border-accent-warm"
+                  : "bg-transparent text-text-secondary border-border-medium hover:border-accent-warm/40"
+              }`}
             >
-              ×
+              🏪 自分の店の写真
+            </button>
+            <button
+              type="button"
+              onClick={() => setImageType("reference")}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-all duration-200 border ${
+                imageType === "reference"
+                  ? "bg-accent-gold text-white border-accent-gold"
+                  : "bg-transparent text-text-secondary border-border-medium hover:border-accent-gold/40"
+              }`}
+            >
+              🎨 参考イメージ
             </button>
           </div>
-          <span className="text-xs text-text-muted truncate max-w-[200px]">
-            {imagePreview.attachment.fileName}
-          </span>
         </div>
       )}
 

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -101,23 +101,42 @@ export default function ChatMessage({
         {/* 画像アップロード */}
         {msg.image && (
           <div className="mt-2.5 rounded-[12px] overflow-hidden border border-border-light max-w-[240px]">
-            {msg.image.publicUrl ? (
+            {msg.image.publicUrl && (
               <img
                 src={msg.image.publicUrl}
                 alt={msg.image.fileName}
                 className="max-w-[240px] max-h-[200px] object-cover"
+                onError={(e) => {
+                  e.currentTarget.style.display = "none";
+                  const fallback = e.currentTarget.nextElementSibling;
+                  if (fallback instanceof HTMLElement) fallback.style.display = "flex";
+                }}
               />
-            ) : (
-              <div
-                className="h-[140px] flex items-center justify-center text-6xl"
-                style={{ background: msg.image.bgColor }}
-              >
-                {msg.image.emoji}
-              </div>
             )}
-            <div className="px-3 py-2 bg-bg-primary text-[11px] text-text-muted flex justify-between">
+            <div
+              className="h-[140px] items-center justify-center text-6xl"
+              style={{
+                background: msg.image.bgColor,
+                display: msg.image.publicUrl ? "none" : "flex",
+              }}
+            >
+              {msg.image.emoji}
+            </div>
+            <div className="px-3 py-2 bg-bg-primary text-[11px] text-text-muted flex justify-between items-center">
               <span>{msg.image.fileName}</span>
-              <span>{msg.image.fileSize}</span>
+              <div className="flex items-center gap-1.5">
+                {msg.image.imageType === "shop_photo" && (
+                  <span className="px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-accent-warm/10 text-accent-warm">
+                    🏪 店舗
+                  </span>
+                )}
+                {msg.image.imageType === "reference" && (
+                  <span className="px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-accent-gold/15 text-accent-gold">
+                    🎨 参考
+                  </span>
+                )}
+                <span>{msg.image.fileSize}</span>
+              </div>
             </div>
           </div>
         )}

--- a/src/hooks/chat/types.ts
+++ b/src/hooks/chat/types.ts
@@ -20,7 +20,7 @@ export interface UseChatSessionReturn {
   restoredShopName: string | null;
 
   // ハンドラー
-  handleSend: (text: string, image?: { base64: string; mimeType: string; fileName: string }) => Promise<void>;
+  handleSend: (text: string, image?: { base64: string; mimeType: string; fileName: string; imageType?: "shop_photo" | "reference" }) => Promise<void>;
   handleQuickReply: (reply: string) => void;
   handleApproveProposal: () => void;
   handleReviseProposal: () => void;

--- a/src/hooks/chat/useChatFlow.ts
+++ b/src/hooks/chat/useChatFlow.ts
@@ -124,7 +124,7 @@ export function useChatFlow({
       setIsTyping: (v: boolean) => void;
       setCurrentProposal: (p: MessageType["proposal"] | null) => void;
     },
-    image?: { base64: string; mimeType: string; fileName: string }
+    image?: { base64: string; mimeType: string; fileName: string; imageType?: "shop_photo" | "reference" }
   ) => {
     const { setMessages, setIsTyping, setCurrentProposal } = callbacks;
 
@@ -151,14 +151,16 @@ export function useChatFlow({
           const publicUrl = `${supabaseUrl}/storage/v1/object/public/uploads/${uploadData.storagePath}`;
 
           const fileSizeKB = Math.round((uploadData.compressedSize || image.base64.length * 0.75) / 1024);
+          const isReference = image.imageType === "reference";
           imageData = {
-            emoji: "📷",
+            emoji: isReference ? "🎨" : "📷",
             fileName: image.fileName,
             fileSize: `${fileSizeKB}KB`,
-            bgColor: "#F5F3F0",
+            bgColor: isReference ? "#FFF8E7" : "#F5F3F0",
             storagePath: uploadData.storagePath,
             publicUrl,
             mimeType: uploadData.mimeType || image.mimeType,
+            imageType: image.imageType,
           };
           imageBase64ForApi = image.base64;
           imageMimeTypeForApi = image.mimeType;

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -23,6 +23,9 @@ export function useChatSession(
     MessageType["proposal"] | null
   >(null);
   const [currentStep, setCurrentStep] = useState<FlowStep>(1);
+  const [referenceImages, setReferenceImages] = useState<
+    Array<{ base64: string; mimeType: string; fileName: string }>
+  >([]);
 
   // --- セッション復元 ---
   const {
@@ -74,6 +77,7 @@ export function useChatSession(
       onMessagesAdd,
       onStepChange,
       saveImage,
+      referenceImages,
     });
 
   // --- チャットフロー ---
@@ -86,7 +90,15 @@ export function useChatSession(
 
   // --- ハンドラー ---
 
-  const handleSend = async (text: string, image?: { base64: string; mimeType: string; fileName: string }) => {
+  const handleSend = async (text: string, image?: { base64: string; mimeType: string; fileName: string; imageType?: "shop_photo" | "reference" }) => {
+    // 参考イメージの場合、referenceImagesに蓄積
+    if (image && image.imageType === "reference") {
+      setReferenceImages((prev) => [
+        ...prev,
+        { base64: image.base64, mimeType: image.mimeType, fileName: image.fileName },
+      ]);
+    }
+
     const sid = await ensureSession();
     await sendMessage(text, messages, sid, {
       setMessages,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,9 @@
 // MenuCraft AI - 共通型定義
 // ========================================
 
+// --- 画像タイプ ---
+export type ImageType = "shop_photo" | "reference";
+
 // --- Proposal（構成案）---
 export interface Proposal {
   shopName: string;
@@ -24,6 +27,7 @@ export interface MessageImage {
   storagePath?: string;
   publicUrl?: string;
   mimeType?: string;
+  imageType?: ImageType;
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary

- チャット画像アップロード時に「🏪 自分の店の写真」「🎨 参考イメージ」のタグ選択UIを追加
- 参考イメージは画像生成時にGeminiへスタイルガイドとして送信（最新3枚まで）
- ChatMessageに画像タイプバッジ表示（既存メッセージは後方互換でバッジ非表示）
- 画像URL読み込み失敗時の絵文字フォールバック表示を追加

## Changed files (8)

| # | File | Change |
|---|------|--------|
| 1 | `src/lib/types.ts` | `ImageType` 型 + `imageType` フィールド追加 |
| 2 | `src/hooks/chat/types.ts` | `handleSend` シグネチャに `imageType` 追加 |
| 3 | `src/components/chat/ChatInput.tsx` | タグ選択チップUI（🏪/🎨）追加 |
| 4 | `src/hooks/chat/useChatFlow.ts` | imageType に応じた emoji/bgColor 切り替え |
| 5 | `src/components/chat/ChatMessage.tsx` | タイプバッジ表示 + onError フォールバック |
| 6 | `src/hooks/useChatSession.ts` | `referenceImages` state 蓄積 |
| 7 | `src/hooks/chat/useImageGeneration.ts` | 参考画像をAPI送信（最新3枚制限） |
| 8 | `src/app/api/generate-image/route.ts` | ユーザー参考画像を contentParts にマージ |

## Test plan

- [ ] 📎で画像選択 → タグ選択チップが表示される
- [ ] デフォルトは「🏪 自分の店の写真」
- [ ] 「🎨 参考イメージ」に切り替え可能
- [ ] 送信後、ChatMessage にタイプバッジが表示される
- [ ] タグ無しの既存メッセージにバッジが表示されない（後方互換）
- [ ] テキストのみ送信・店舗写真のみ送信が従来通り動作する
- [ ] 画像URL読み込み失敗時に絵文字フォールバックが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)