### PR TITLE
feat: プロンプトモード（Pro限定）を実装

### DIFF
--- a/src/app/api/prompts/mine/[id]/route.ts
+++ b/src/app/api/prompts/mine/[id]/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { createAdminClient } from "@/lib/supabase";
+
+// プロンプト編集
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です。" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const supabase = createAdminClient();
+
+    // 所有者チェック
+    const { data: existing } = await supabase
+      .from("user_prompts")
+      .select("id, user_id")
+      .eq("id", id)
+      .single();
+
+    if (!existing || existing.user_id !== session.user.id) {
+      return NextResponse.json({ error: "このプロンプトを編集する権限がありません。" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+    if (body.name !== undefined) {
+      if (typeof body.name !== "string" || body.name.trim().length === 0 || body.name.length > 100) {
+        return NextResponse.json({ error: "名前は1〜100文字で入力してください。" }, { status: 400 });
+      }
+      updates.name = body.name.trim();
+    }
+    if (body.prompt_text !== undefined) {
+      if (typeof body.prompt_text !== "string" || body.prompt_text.trim().length === 0 || body.prompt_text.length > 2000) {
+        return NextResponse.json({ error: "プロンプトは1〜2000文字で入力してください。" }, { status: 400 });
+      }
+      updates.prompt_text = body.prompt_text.trim();
+    }
+    if (body.category !== undefined) {
+      updates.category = body.category || null;
+    }
+    if (typeof body.usage_count === "number") {
+      updates.usage_count = body.usage_count;
+    }
+
+    const { data, error } = await supabase
+      .from("user_prompts")
+      .update(updates)
+      .eq("id", id)
+      .select("id, name, prompt_text, category, usage_count, created_at, updated_at")
+      .single();
+
+    if (error) {
+      console.error("Prompt update error:", error);
+      return NextResponse.json({ error: "更新に失敗しました。" }, { status: 500 });
+    }
+
+    return NextResponse.json({ prompt: data });
+  } catch {
+    return NextResponse.json({ error: "サーバーエラーが発生しました。" }, { status: 500 });
+  }
+}
+
+// プロンプト削除
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です。" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const supabase = createAdminClient();
+
+    // 所有者チェック
+    const { data: existing } = await supabase
+      .from("user_prompts")
+      .select("id, user_id")
+      .eq("id", id)
+      .single();
+
+    if (!existing || existing.user_id !== session.user.id) {
+      return NextResponse.json({ error: "このプロンプトを削除する権限がありません。" }, { status: 403 });
+    }
+
+    const { error } = await supabase
+      .from("user_prompts")
+      .delete()
+      .eq("id", id);
+
+    if (error) {
+      console.error("Prompt delete error:", error);
+      return NextResponse.json({ error: "削除に失敗しました。" }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "サーバーエラーが発生しました。" }, { status: 500 });
+  }
+}

--- a/src/app/api/prompts/mine/route.ts
+++ b/src/app/api/prompts/mine/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { createAdminClient } from "@/lib/supabase";
+
+// マイプロンプト一覧
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です。" }, { status: 401 });
+  }
+
+  try {
+    const supabase = createAdminClient();
+
+    const { data, error } = await supabase
+      .from("user_prompts")
+      .select("id, name, prompt_text, category, usage_count, created_at, updated_at")
+      .eq("user_id", session.user.id)
+      .order("updated_at", { ascending: false });
+
+    if (error) {
+      console.error("Prompts list error:", error);
+      return NextResponse.json({ error: "取得に失敗しました。" }, { status: 500 });
+    }
+
+    return NextResponse.json({ prompts: data || [] });
+  } catch {
+    return NextResponse.json({ error: "サーバーエラーが発生しました。" }, { status: 500 });
+  }
+}
+
+// プロンプト保存
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です。" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const { name, prompt_text, category } = body;
+
+    // バリデーション
+    if (!name || typeof name !== "string" || name.trim().length === 0 || name.length > 100) {
+      return NextResponse.json({ error: "名前は1〜100文字で入力してください。" }, { status: 400 });
+    }
+    if (!prompt_text || typeof prompt_text !== "string" || prompt_text.trim().length === 0 || prompt_text.length > 2000) {
+      return NextResponse.json({ error: "プロンプトは1〜2000文字で入力してください。" }, { status: 400 });
+    }
+
+    const supabase = createAdminClient();
+
+    const { data, error } = await supabase
+      .from("user_prompts")
+      .insert({
+        user_id: session.user.id,
+        name: name.trim(),
+        prompt_text: prompt_text.trim(),
+        category: category || null,
+      })
+      .select("id, name, prompt_text, category, usage_count, created_at, updated_at")
+      .single();
+
+    if (error) {
+      console.error("Prompt save error:", error);
+      return NextResponse.json({ error: "保存に失敗しました。" }, { status: 500 });
+    }
+
+    return NextResponse.json({ prompt: data });
+  } catch {
+    return NextResponse.json({ error: "サーバーエラーが発生しました。" }, { status: 500 });
+  }
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -6,10 +6,13 @@ import Header from "@/components/landing/Header";
 import ChatMessage from "@/components/chat/ChatMessage";
 import ChatInput from "@/components/chat/ChatInput";
 import PreviewPanel from "@/components/chat/PreviewPanel";
+import PromptMode from "@/components/chat/PromptMode";
+import SavePromptModal from "@/components/chat/SavePromptModal";
 import Link from "next/link";
 import AdPlaceholder from "@/components/AdPlaceholder";
 import { useChatSession } from "@/hooks/useChatSession";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import type { GeneratedImage } from "@/lib/types";
 
 // useSearchParamsを使うコンポーネントをSuspenseでラップ
 export default function ChatPage() {
@@ -38,8 +41,10 @@ function ChatPageInner() {
     generatedImage,
     currentProposal,
     currentStep,
+    sessionId,
     isRestoring,
     restoredShopName,
+    lastUsedPrompt,
     handleSend,
     handleQuickReply,
     handleApproveProposal,
@@ -51,6 +56,11 @@ function ChatPageInner() {
   const isOnline = useOnlineStatus();
 
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [promptMode, setPromptMode] = useState(false);
+  const [promptGeneratedImage, setPromptGeneratedImage] = useState<GeneratedImage | null>(null);
+  const [promptIsGenerating, setPromptIsGenerating] = useState(false);
+  const [promptLastUsedPrompt, setPromptLastUsedPrompt] = useState<string | null>(null);
+  const [showSavePromptModal, setShowSavePromptModal] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // 画面幅に応じてプレビューのデフォルト状態を設定
@@ -62,10 +72,10 @@ function ChatPageInner() {
 
   // 画像生成開始時にプレビューを自動で開く
   useEffect(() => {
-    if (isGeneratingImage) {
+    if (isGeneratingImage || promptIsGenerating) {
       setPreviewOpen(true);
     }
-  }, [isGeneratingImage]);
+  }, [isGeneratingImage, promptIsGenerating]);
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -74,6 +84,47 @@ function ChatPageInner() {
   useEffect(() => {
     scrollToBottom();
   }, [messages, isTyping, scrollToBottom]);
+
+  // プロンプトモードからの画像生成
+  const handlePromptGenerate = async (prompt: string, aspectRatio: string) => {
+    setPromptIsGenerating(true);
+    setPromptGeneratedImage(null);
+    setPromptLastUsedPrompt(prompt);
+
+    try {
+      const res = await fetch("/api/generate-image", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt,
+          aspectRatio,
+          sessionId: sessionId || undefined,
+        }),
+      });
+
+      const data = await res.json().catch(() => ({ error: "" }));
+
+      if (!res.ok || data.error) {
+        setPromptGeneratedImage(null);
+      } else if (data.image) {
+        setPromptGeneratedImage({ data: data.image, mimeType: data.mimeType });
+      }
+    } catch {
+      setPromptGeneratedImage(null);
+    } finally {
+      setPromptIsGenerating(false);
+    }
+  };
+
+  // 表示する画像・生成状態をモードで切替
+  const displayImage = promptMode ? promptGeneratedImage : generatedImage;
+  const displayIsGenerating = promptMode ? promptIsGenerating : isGeneratingImage;
+  const displayLastUsedPrompt = promptMode ? promptLastUsedPrompt : lastUsedPrompt;
+
+  // プロンプト保存モーダルの表示
+  const handleOpenSavePrompt = () => {
+    setShowSavePromptModal(true);
+  };
 
   return (
     <>
@@ -99,11 +150,23 @@ function ChatPageInner() {
                     : "メニューデザイン - 新規作成"}
                 </div>
                 <div className="text-xs text-text-muted hidden sm:block">
-                  AIアシスタントとチャット
+                  {promptMode ? "プロンプトモード" : "AIアシスタントとチャット"}
                 </div>
               </div>
             </div>
             <div className="flex gap-2">
+              {/* プロンプトモード切替 */}
+              <button
+                onClick={() => setPromptMode(!promptMode)}
+                title="プロンプトモード切替"
+                className={`h-9 px-3 rounded-full border text-xs font-semibold cursor-pointer flex items-center justify-center gap-1.5 transition-all duration-300 ${
+                  promptMode
+                    ? "bg-accent-warm text-white border-accent-warm shadow-[0_2px_8px_rgba(232,113,58,.2)]"
+                    : "bg-bg-secondary text-text-secondary border-border-light hover:bg-accent-warm/10 hover:text-accent-warm hover:border-accent-warm/30"
+                }`}
+              >
+                ⚡ プロンプト
+              </button>
               <button
                 onClick={() => setPreviewOpen(!previewOpen)}
                 title="プレビュー切替"
@@ -137,67 +200,90 @@ function ChatPageInner() {
             </div>
           )}
 
-          {/* メッセージ一覧 */}
-          <div className="relative z-10 flex-1 overflow-y-auto px-4 md:px-7 py-5 md:py-7 flex flex-col gap-4 md:gap-5">
-            {isRestoring ? (
-              <div className="flex-1 flex items-center justify-center">
-                <div className="text-center">
-                  <div className="text-4xl mb-3 animate-bounce">🍽</div>
-                  <div className="text-sm text-text-muted">会話履歴を復元中...</div>
-                </div>
-              </div>
-            ) : null}
-            {!isRestoring && messages.map((msg) => (
-              <ChatMessage
-                key={msg.id}
-                msg={msg}
-                onQuickReply={handleQuickReply}
-                onApproveProposal={handleApproveProposal}
-                onReviseProposal={handleReviseProposal}
-                onRetry={handleRetry}
-                disabled={isTyping || isGeneratingImage}
-              />
-            ))}
-
-            {/* タイピングインジケーター（復元中は非表示） */}
-            {isTyping && (
-              <div className="flex gap-3 max-w-[720px] self-start animate-[msgIn_0.4s_ease-out]">
-                <div className="w-9 h-9 rounded-full flex-shrink-0 flex items-center justify-center text-base bg-gradient-to-br from-avatar-ai-from to-avatar-ai-to border border-avatar-ai-border">
-                  🍽
-                </div>
-                <div className="px-5 py-4 rounded-[20px] rounded-tl-[4px] bg-bg-secondary border border-border-light">
-                  <div className="flex gap-1">
-                    <div className="w-1.5 h-1.5 rounded-full bg-text-muted animate-bounce" style={{ animationDelay: "0ms" }} />
-                    <div className="w-1.5 h-1.5 rounded-full bg-text-muted animate-bounce" style={{ animationDelay: "200ms" }} />
-                    <div className="w-1.5 h-1.5 rounded-full bg-text-muted animate-bounce" style={{ animationDelay: "400ms" }} />
+          {promptMode ? (
+            /* プロンプトモード */
+            <PromptMode
+              onGenerate={handlePromptGenerate}
+              isGenerating={promptIsGenerating}
+            />
+          ) : (
+            <>
+              {/* メッセージ一覧 */}
+              <div className="relative z-10 flex-1 overflow-y-auto px-4 md:px-7 py-5 md:py-7 flex flex-col gap-4 md:gap-5">
+                {isRestoring ? (
+                  <div className="flex-1 flex items-center justify-center">
+                    <div className="text-center">
+                      <div className="text-4xl mb-3 animate-bounce">🍽</div>
+                      <div className="text-sm text-text-muted">会話履歴を復元中...</div>
+                    </div>
                   </div>
-                </div>
+                ) : null}
+                {!isRestoring && messages.map((msg) => (
+                  <ChatMessage
+                    key={msg.id}
+                    msg={msg}
+                    onQuickReply={handleQuickReply}
+                    onApproveProposal={handleApproveProposal}
+                    onReviseProposal={handleReviseProposal}
+                    onRetry={handleRetry}
+                    disabled={isTyping || isGeneratingImage}
+                  />
+                ))}
+
+                {/* タイピングインジケーター（復元中は非表示） */}
+                {isTyping && (
+                  <div className="flex gap-3 max-w-[720px] self-start animate-[msgIn_0.4s_ease-out]">
+                    <div className="w-9 h-9 rounded-full flex-shrink-0 flex items-center justify-center text-base bg-gradient-to-br from-avatar-ai-from to-avatar-ai-to border border-avatar-ai-border">
+                      🍽
+                    </div>
+                    <div className="px-5 py-4 rounded-[20px] rounded-tl-[4px] bg-bg-secondary border border-border-light">
+                      <div className="flex gap-1">
+                        <div className="w-1.5 h-1.5 rounded-full bg-text-muted animate-bounce" style={{ animationDelay: "0ms" }} />
+                        <div className="w-1.5 h-1.5 rounded-full bg-text-muted animate-bounce" style={{ animationDelay: "200ms" }} />
+                        <div className="w-1.5 h-1.5 rounded-full bg-text-muted animate-bounce" style={{ animationDelay: "400ms" }} />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                <div ref={messagesEndRef} />
               </div>
-            )}
 
-            <div ref={messagesEndRef} />
-          </div>
+              {/* 広告プレースホルダー */}
+              <div className="relative z-10 px-4 md:px-7 flex-shrink-0">
+                <AdPlaceholder variant="inline" />
+              </div>
 
-          {/* 広告プレースホルダー */}
-          <div className="relative z-10 px-4 md:px-7 flex-shrink-0">
-            <AdPlaceholder variant="inline" />
-          </div>
-
-          {/* 入力エリア */}
-          <ChatInput onSend={handleSend} disabled={isTyping || isGeneratingImage || isRestoring || !isOnline} />
+              {/* 入力エリア */}
+              <ChatInput onSend={handleSend} disabled={isTyping || isGeneratingImage || isRestoring || !isOnline} />
+            </>
+          )}
         </div>
 
         {/* プレビューパネル */}
         <PreviewPanel
           isOpen={previewOpen}
           onToggle={() => setPreviewOpen(false)}
-          generatedImage={generatedImage}
-          isGenerating={isGeneratingImage}
-          onRegenerate={handleRegenerate}
-          proposal={currentProposal}
-          currentStep={currentStep}
+          generatedImage={displayImage}
+          isGenerating={displayIsGenerating}
+          onRegenerate={promptMode ? undefined : handleRegenerate}
+          proposal={promptMode ? undefined : currentProposal}
+          currentStep={promptMode ? undefined : currentStep}
+          lastUsedPrompt={displayLastUsedPrompt}
+          onSavePrompt={displayLastUsedPrompt ? handleOpenSavePrompt : undefined}
+          shopName={restoredShopName || undefined}
         />
       </div>
+
+      {/* プロンプト保存モーダル */}
+      {showSavePromptModal && displayLastUsedPrompt && (
+        <SavePromptModal
+          promptText={displayLastUsedPrompt}
+          shopName={restoredShopName || undefined}
+          onClose={() => setShowSavePromptModal(false)}
+          onSaved={() => setShowSavePromptModal(false)}
+        />
+      )}
     </>
   );
 }

--- a/src/components/chat/PreviewPanel.tsx
+++ b/src/components/chat/PreviewPanel.tsx
@@ -86,6 +86,8 @@ export default function PreviewPanel({
   generatedImageUrl,
   sessionCategory,
   shopName,
+  lastUsedPrompt,
+  onSavePrompt,
 }: {
   isOpen: boolean;
   onToggle: () => void;
@@ -98,6 +100,8 @@ export default function PreviewPanel({
   generatedImageUrl?: string | null;
   sessionCategory?: string;
   shopName?: string;
+  lastUsedPrompt?: string | null;
+  onSavePrompt?: () => void;
 }) {
   const [activeRatio, setActiveRatio] = useState<RatioKey>("1-1");
   const [showShareModal, setShowShareModal] = useState(false);
@@ -273,6 +277,14 @@ export default function PreviewPanel({
             </svg>
             この画像をダウンロード
           </button>
+          {generatedImage && lastUsedPrompt && onSavePrompt && (
+            <button
+              onClick={onSavePrompt}
+              className="w-full py-3 rounded-full text-[13px] font-semibold bg-transparent text-accent-gold border border-accent-gold/30 cursor-pointer flex items-center justify-center gap-2 transition-all duration-300 hover:bg-accent-gold/10 hover:border-accent-gold/50"
+            >
+              📝 プロンプトを保存
+            </button>
+          )}
           {generatedImage && generatedImageId && !shared && (
             <button
               onClick={() => setShowShareModal(true)}

--- a/src/components/chat/PromptMode.tsx
+++ b/src/components/chat/PromptMode.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { UserPrompt } from "@/lib/types";
+
+const ASPECT_RATIOS = [
+  { key: "1:1", label: "1:1 Feed" },
+  { key: "9:16", label: "9:16 Story" },
+  { key: "16:9", label: "16:9 X Post" },
+] as const;
+
+const CATEGORIES = [
+  { value: "", label: "なし" },
+  { value: "cafe", label: "カフェ" },
+  { value: "izakaya", label: "居酒屋" },
+  { value: "italian", label: "イタリアン" },
+  { value: "sweets", label: "スイーツ" },
+  { value: "ramen", label: "ラーメン" },
+  { value: "chinese", label: "中華" },
+  { value: "japanese", label: "和食" },
+  { value: "other", label: "その他" },
+];
+
+type Props = {
+  onGenerate: (prompt: string, aspectRatio: string) => void;
+  isGenerating: boolean;
+};
+
+export default function PromptMode({ onGenerate, isGenerating }: Props) {
+  const [prompts, setPrompts] = useState<UserPrompt[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [promptText, setPromptText] = useState("");
+  const [aspectRatio, setAspectRatio] = useState("1:1");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editText, setEditText] = useState("");
+  const [editCategory, setEditCategory] = useState("");
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+  const fetchPrompts = useCallback(async () => {
+    try {
+      const res = await fetch("/api/prompts/mine");
+      if (res.ok) {
+        const data = await res.json();
+        setPrompts(data.prompts || []);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPrompts();
+  }, [fetchPrompts]);
+
+  const handleSelectPrompt = (prompt: UserPrompt) => {
+    setPromptText(prompt.prompt_text);
+
+    // usage_count をインクリメント（非ブロッキング）
+    fetch(`/api/prompts/mine/${prompt.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ usage_count: prompt.usage_count + 1 }),
+    }).then(() => {
+      setPrompts((prev) =>
+        prev.map((p) =>
+          p.id === prompt.id ? { ...p, usage_count: p.usage_count + 1 } : p
+        )
+      );
+    }).catch(() => {});
+  };
+
+  const handleGenerate = () => {
+    if (!promptText.trim() || isGenerating) return;
+    onGenerate(promptText.trim(), aspectRatio);
+  };
+
+  const handleStartEdit = (prompt: UserPrompt) => {
+    setEditingId(prompt.id);
+    setEditName(prompt.name);
+    setEditText(prompt.prompt_text);
+    setEditCategory(prompt.category || "");
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editName.trim() || !editText.trim()) return;
+    try {
+      const res = await fetch(`/api/prompts/mine/${editingId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: editName.trim(),
+          prompt_text: editText.trim(),
+          category: editCategory || null,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setPrompts((prev) =>
+          prev.map((p) => (p.id === editingId ? data.prompt : p))
+        );
+        setEditingId(null);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      const res = await fetch(`/api/prompts/mine/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setPrompts((prev) => prev.filter((p) => p.id !== id));
+        setDeleteConfirmId(null);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 md:px-7 py-5 md:py-7 flex flex-col gap-5">
+      {/* ヘッダー */}
+      <div className="flex items-center gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-semibold text-accent-warm uppercase tracking-[1.5px]">
+              Prompt Mode
+            </span>
+            <span className="px-2 py-0.5 rounded-full bg-accent-gold/15 text-accent-gold text-[10px] font-bold tracking-wider">
+              PRO
+            </span>
+          </div>
+          <div className="font-semibold text-sm mt-0.5">プロンプトモード</div>
+          <div className="text-xs text-text-muted mt-0.5">
+            保存済みプロンプトを選択するか、直接入力して画像を生成
+          </div>
+        </div>
+      </div>
+
+      {/* 保存済みプロンプト一覧 */}
+      <div>
+        <div className="text-[11px] font-semibold text-text-secondary uppercase tracking-[1px] mb-3">
+          保存済みプロンプト
+        </div>
+        {loading ? (
+          <div className="text-sm text-text-muted py-4 text-center">読み込み中...</div>
+        ) : prompts.length === 0 ? (
+          <div className="p-4 bg-bg-secondary rounded-[16px] border border-border-light text-sm text-text-muted text-center">
+            保存されたプロンプトはありません。
+            <br />
+            <span className="text-xs">画像生成後にプレビューパネルから保存できます。</span>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {prompts.map((prompt) => (
+              <div key={prompt.id}>
+                {editingId === prompt.id ? (
+                  /* 編集モード */
+                  <div className="p-4 bg-bg-secondary rounded-[16px] border border-accent-warm/30 flex flex-col gap-3">
+                    <input
+                      type="text"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      maxLength={100}
+                      className="w-full px-3 py-2 rounded-[10px] border border-border-light bg-bg-primary text-sm focus:outline-none focus:border-accent-warm transition-colors"
+                      placeholder="プロンプト名"
+                    />
+                    <textarea
+                      value={editText}
+                      onChange={(e) => setEditText(e.target.value)}
+                      maxLength={2000}
+                      rows={4}
+                      className="w-full px-3 py-2 rounded-[10px] border border-border-light bg-bg-primary text-sm focus:outline-none focus:border-accent-warm transition-colors resize-y"
+                    />
+                    <select
+                      value={editCategory}
+                      onChange={(e) => setEditCategory(e.target.value)}
+                      className="w-full px-3 py-2 rounded-[10px] border border-border-light bg-bg-primary text-sm focus:outline-none focus:border-accent-warm transition-colors"
+                    >
+                      {CATEGORIES.map((c) => (
+                        <option key={c.value} value={c.value}>{c.label}</option>
+                      ))}
+                    </select>
+                    <div className="flex gap-2 justify-end">
+                      <button
+                        onClick={() => setEditingId(null)}
+                        className="px-4 py-1.5 rounded-full text-xs text-text-secondary border border-border-light bg-transparent hover:bg-bg-primary transition-colors cursor-pointer"
+                      >
+                        キャンセル
+                      </button>
+                      <button
+                        onClick={handleSaveEdit}
+                        disabled={!editName.trim() || !editText.trim()}
+                        className="px-4 py-1.5 rounded-full text-xs text-white bg-accent-warm hover:bg-accent-warm-hover transition-colors cursor-pointer disabled:opacity-50"
+                      >
+                        保存
+                      </button>
+                    </div>
+                  </div>
+                ) : deleteConfirmId === prompt.id ? (
+                  /* 削除確認 */
+                  <div className="p-4 bg-red-50 rounded-[16px] border border-red-200 flex items-center justify-between gap-3">
+                    <div className="text-sm text-red-700">
+                      「{prompt.name}」を削除しますか？
+                    </div>
+                    <div className="flex gap-2 flex-shrink-0">
+                      <button
+                        onClick={() => setDeleteConfirmId(null)}
+                        className="px-3 py-1.5 rounded-full text-xs text-text-secondary border border-border-light bg-white hover:bg-bg-primary transition-colors cursor-pointer"
+                      >
+                        戻る
+                      </button>
+                      <button
+                        onClick={() => handleDelete(prompt.id)}
+                        className="px-3 py-1.5 rounded-full text-xs text-white bg-red-500 hover:bg-red-600 transition-colors cursor-pointer"
+                      >
+                        削除
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  /* 通常表示 */
+                  <div
+                    onClick={() => handleSelectPrompt(prompt)}
+                    className="p-4 bg-bg-secondary rounded-[16px] border border-border-light cursor-pointer transition-all duration-300 hover:border-accent-warm/30 hover:shadow-[0_2px_12px_rgba(232,113,58,.08)] group relative overflow-hidden"
+                  >
+                    <div className="absolute top-0 left-0 right-0 h-[2px] bg-accent-gold opacity-0 group-hover:opacity-40 transition-opacity" />
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="font-semibold text-sm truncate">{prompt.name}</span>
+                          {prompt.category && (
+                            <span className="px-2 py-0.5 rounded-full bg-accent-olive/15 text-accent-olive text-[10px] font-medium flex-shrink-0">
+                              {prompt.category}
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-text-muted line-clamp-2">
+                          {prompt.prompt_text}
+                        </div>
+                        <div className="text-[10px] text-text-muted mt-1.5">
+                          使用回数: {prompt.usage_count}
+                        </div>
+                      </div>
+                      <div className="flex gap-1 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                        <button
+                          onClick={() => handleStartEdit(prompt)}
+                          title="編集"
+                          className="w-7 h-7 rounded-full border border-border-light bg-bg-primary flex items-center justify-center text-text-muted hover:text-accent-warm hover:border-accent-warm/30 transition-colors cursor-pointer text-xs"
+                        >
+                          ✏️
+                        </button>
+                        <button
+                          onClick={() => setDeleteConfirmId(prompt.id)}
+                          title="削除"
+                          className="w-7 h-7 rounded-full border border-border-light bg-bg-primary flex items-center justify-center text-text-muted hover:text-red-500 hover:border-red-200 transition-colors cursor-pointer text-xs"
+                        >
+                          🗑️
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* プロンプト入力エリア */}
+      <div>
+        <div className="text-[11px] font-semibold text-text-secondary uppercase tracking-[1px] mb-3">
+          プロンプト入力
+        </div>
+        <textarea
+          value={promptText}
+          onChange={(e) => setPromptText(e.target.value)}
+          maxLength={2000}
+          rows={6}
+          placeholder="画像生成プロンプトを入力してください...&#10;例: A professional food photography for a restaurant menu..."
+          className="w-full px-4 py-3 rounded-[16px] border border-border-light bg-bg-secondary text-sm leading-relaxed focus:outline-none focus:border-accent-warm transition-colors resize-y"
+        />
+        <div className="text-xs text-text-muted text-right mt-1">
+          {promptText.length}/2000
+        </div>
+      </div>
+
+      {/* アスペクト比選択 */}
+      <div>
+        <div className="text-[11px] font-semibold text-text-secondary uppercase tracking-[1px] mb-3">
+          アスペクト比
+        </div>
+        <div className="flex gap-2">
+          {ASPECT_RATIOS.map((ratio) => (
+            <button
+              key={ratio.key}
+              onClick={() => setAspectRatio(ratio.key)}
+              className={`px-4 py-2 rounded-full text-xs font-medium cursor-pointer border transition-all duration-300 ${
+                aspectRatio === ratio.key
+                  ? "bg-accent-warm text-white border-accent-warm shadow-[0_2px_8px_rgba(232,113,58,.2)]"
+                  : "bg-transparent text-text-secondary border-border-light hover:border-accent-warm/30 hover:text-accent-warm"
+              }`}
+            >
+              {ratio.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 生成ボタン */}
+      <button
+        onClick={handleGenerate}
+        disabled={!promptText.trim() || isGenerating}
+        className="w-full py-4 rounded-full border-none text-[15px] font-bold bg-accent-warm text-white cursor-pointer flex items-center justify-center gap-2 transition-all duration-300 hover:bg-accent-warm-hover hover:shadow-[0_4px_16px_rgba(232,113,58,.25)] hover:-translate-y-0.5 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none"
+      >
+        {isGenerating ? (
+          <>
+            <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+            生成中...
+          </>
+        ) : (
+          <>
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <path d="M9 2L11.5 7L17 7.5L13 11.5L14 17L9 14L4 17L5 11.5L1 7.5L6.5 7L9 2Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+            </svg>
+            画像を生成する
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/components/chat/SavePromptModal.tsx
+++ b/src/components/chat/SavePromptModal.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+
+const CATEGORIES = [
+  { value: "", label: "なし" },
+  { value: "cafe", label: "カフェ" },
+  { value: "izakaya", label: "居酒屋" },
+  { value: "italian", label: "イタリアン" },
+  { value: "sweets", label: "スイーツ" },
+  { value: "ramen", label: "ラーメン" },
+  { value: "chinese", label: "中華" },
+  { value: "japanese", label: "和食" },
+  { value: "other", label: "その他" },
+];
+
+type Props = {
+  promptText: string;
+  shopName?: string;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+export default function SavePromptModal({
+  promptText,
+  shopName,
+  onClose,
+  onSaved,
+}: Props) {
+  const defaultName = shopName ? `${shopName} プロンプト` : "マイプロンプト";
+  const [name, setName] = useState(defaultName);
+  const [text, setText] = useState(promptText);
+  const [category, setCategory] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  const handleSave = async () => {
+    if (!name.trim() || !text.trim()) return;
+    setSaving(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/prompts/mine", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          prompt_text: text.trim(),
+          category: category || undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "保存に失敗しました。");
+        return;
+      }
+
+      setSaved(true);
+      setTimeout(() => {
+        onSaved();
+      }, 800);
+    } catch {
+      setError("サーバーエラーが発生しました。");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100]">
+      <div className="bg-bg-secondary rounded-[20px] border border-border-light max-w-[480px] w-full mx-4 relative overflow-hidden animate-fade-in-up shadow-[0_20px_60px_rgba(0,0,0,.15)]">
+        {/* アクセントバー */}
+        <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-accent-warm via-accent-gold to-transparent" />
+
+        <div className="p-6">
+          <h3 className="text-lg font-bold mb-4 flex items-center gap-2">
+            <span>📝</span>
+            プロンプトを保存
+          </h3>
+
+          {saved ? (
+            <div className="text-center py-8">
+              <div className="text-4xl mb-3">✅</div>
+              <div className="text-sm font-semibold text-accent-olive">保存しました！</div>
+            </div>
+          ) : (
+            <>
+              {/* プロンプト名 */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium mb-2">プロンプト名</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  maxLength={100}
+                  className="w-full px-4 py-2.5 rounded-[12px] border border-border-light bg-bg-primary text-sm focus:outline-none focus:border-accent-warm transition-colors"
+                  placeholder="例: カフェメニュー用プロンプト"
+                />
+              </div>
+
+              {/* プロンプト内容 */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium mb-2">プロンプト内容</label>
+                <textarea
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                  maxLength={2000}
+                  rows={6}
+                  className="w-full px-4 py-2.5 rounded-[12px] border border-border-light bg-bg-primary text-sm focus:outline-none focus:border-accent-warm transition-colors resize-y"
+                  placeholder="画像生成に使うプロンプトを入力..."
+                />
+                <div className="text-xs text-text-muted text-right mt-1">
+                  {text.length}/2000
+                </div>
+              </div>
+
+              {/* カテゴリ選択 */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium mb-2">カテゴリ（任意）</label>
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  className="w-full px-4 py-2.5 rounded-[12px] border border-border-light bg-bg-primary text-sm focus:outline-none focus:border-accent-warm transition-colors"
+                >
+                  {CATEGORIES.map((c) => (
+                    <option key={c.value} value={c.value}>
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {error && (
+                <div className="text-sm text-red-500 mb-4">{error}</div>
+              )}
+
+              {/* ボタン */}
+              <div className="flex gap-3">
+                <button
+                  onClick={onClose}
+                  className="flex-1 py-2.5 rounded-[28px] border border-border-light text-sm text-text-secondary cursor-pointer bg-transparent hover:bg-bg-primary transition-colors"
+                >
+                  キャンセル
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={saving || !name.trim() || !text.trim()}
+                  className="flex-1 py-2.5 rounded-[28px] bg-accent-warm text-white text-sm font-semibold cursor-pointer transition-colors hover:bg-accent-warm-hover disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {saving ? "保存中..." : "保存する"}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/chat/useImageGeneration.ts
+++ b/src/hooks/chat/useImageGeneration.ts
@@ -28,6 +28,7 @@ export function useImageGeneration({
   const [generatedImage, setGeneratedImage] = useState<
     GeneratedImage | null | undefined
   >(undefined);
+  const [lastUsedPrompt, setLastUsedPrompt] = useState<string | null>(null);
 
   const generateImage = async (
     proposal: MessageType["proposal"],
@@ -60,6 +61,8 @@ Restaurant: ${proposal.shopName}
 Design style: ${proposal.designDirection || "natural, warm"}
 Mood: appetizing, warm lighting, high-quality food photo
 IMPORTANT: Do NOT include any text, letters, words, numbers, watermarks, or captions in the image. Generate ONLY the food photograph with no text overlay whatsoever.`;
+
+      setLastUsedPrompt(prompt);
 
       const category = inferCategory(proposal);
 
@@ -151,5 +154,5 @@ IMPORTANT: Do NOT include any text, letters, words, numbers, watermarks, or capt
     }
   };
 
-  return { isGeneratingImage, generatedImage, generateImage };
+  return { isGeneratingImage, generatedImage, generateImage, lastUsedPrompt };
 }

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -71,7 +71,7 @@ export function useChatSession(
 
   const onStepChange = useCallback((step: FlowStep) => setCurrentStep(step), []);
 
-  const { isGeneratingImage, generatedImage, generateImage } =
+  const { isGeneratingImage, generatedImage, generateImage, lastUsedPrompt } =
     useImageGeneration({
       sessionId,
       onMessagesAdd,
@@ -164,6 +164,7 @@ export function useChatSession(
     sessionId,
     isRestoring,
     restoredShopName,
+    lastUsedPrompt,
 
     // ハンドラー
     handleSend,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -124,3 +124,14 @@ export type Achievement = {
   unlocked_at: string | null;
   notified: boolean;
 };
+
+// --- ユーザープロンプト ---
+export type UserPrompt = {
+  id: string;
+  name: string;
+  prompt_text: string;
+  category: string | null;
+  usage_count: number;
+  created_at: string;
+  updated_at: string;
+};

--- a/supabase/009_user_prompts.sql
+++ b/supabase/009_user_prompts.sql
@@ -1,0 +1,18 @@
+CREATE TABLE public.user_prompts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  prompt_text text NOT NULL,
+  category text,
+  usage_count int NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_prompts_user_id ON public.user_prompts(user_id);
+
+ALTER TABLE public.user_prompts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "user_prompts_read" ON public.user_prompts FOR SELECT USING (true);
+CREATE POLICY "user_prompts_insert" ON public.user_prompts FOR INSERT WITH CHECK (true);
+CREATE POLICY "user_prompts_update" ON public.user_prompts FOR UPDATE USING (true);
+CREATE POLICY "user_prompts_delete" ON public.user_prompts FOR DELETE USING (true);


### PR DESCRIPTION
## Summary
- チャット画面に「プロンプトモード」切替トグルを追加
- 保存済みプロンプトの一覧表示・選択・編集・削除機能
- 直接プロンプト入力 + アスペクト比選択による画像生成
- PreviewPanelに「プロンプトを保存」ボタンを追加
- user_prompts テーブル + CRUD API（/api/prompts/mine）

## 変更ファイル（10ファイル）
| ファイル | 区分 | 概要 |
|---------|------|------|
| `supabase/009_user_prompts.sql` | 新規 | user_prompts テーブル作成 |
| `src/lib/types.ts` | 修正 | UserPrompt 型追加 |
| `src/app/api/prompts/mine/route.ts` | 新規 | マイプロンプト GET + POST |
| `src/app/api/prompts/mine/[id]/route.ts` | 新規 | プロンプト PATCH + DELETE |
| `src/components/chat/SavePromptModal.tsx` | 新規 | 保存モーダル |
| `src/components/chat/PromptMode.tsx` | 新規 | プロンプトモードUI |
| `src/hooks/chat/useImageGeneration.ts` | 修正 | lastUsedPrompt 追加 |
| `src/hooks/useChatSession.ts` | 修正 | lastUsedPrompt 公開 |
| `src/components/chat/PreviewPanel.tsx` | 修正 | 保存ボタン追加 |
| `src/app/chat/page.tsx` | 修正 | プロンプトモード統合 |

## Test plan
- [ ] チャット画面ヘッダーに「⚡ プロンプト」切替ボタンが表示される
- [ ] プロンプトモード ON → テキストエリア + 生成ボタンが表示される
- [ ] プロンプト入力 → 「画像を生成する」→ PreviewPanel に画像表示
- [ ] PreviewPanel「プロンプトを保存」→ モーダル → 保存成功
- [ ] プロンプトモードに保存済みカードが表示される
- [ ] カードクリック → テキストエリアにプロンプト読み込み
- [ ] カード編集・削除が動作する
- [ ] 対話モードに戻しても正常にチャットが使える

🤖 Generated with [Claude Code](https://claude.com/claude-code)