### PR TITLE
feat: Sprint B — ダッシュボード改善・設定Tier 3

### DIFF
--- a/src/__tests__/lib/greeting.test.ts
+++ b/src/__tests__/lib/greeting.test.ts
@@ -16,14 +16,14 @@ describe("getGreeting", () => {
     expect(getGreeting()).toBe("こんにちは");
   });
 
-  it("夜（20時）は「おつかれさまです」を返す", () => {
+  it("夜（20時）は「こんばんは」を返す", () => {
     vi.setSystemTime(new Date(2025, 0, 1, 20, 0, 0));
-    expect(getGreeting()).toBe("おつかれさまです");
+    expect(getGreeting()).toBe("こんばんは");
   });
 
-  it("深夜（3時）は「おつかれさまです」を返す", () => {
+  it("深夜（3時）は「こんばんは」を返す", () => {
     vi.setSystemTime(new Date(2025, 0, 1, 3, 0, 0));
-    expect(getGreeting()).toBe("おつかれさまです");
+    expect(getGreeting()).toBe("こんばんは");
   });
 });
 
@@ -38,5 +38,13 @@ describe("getStatsMessage", () => {
 
   it("セッション0件の場合は初回誘導メッセージを返す", () => {
     expect(getStatsMessage(0, 0)).toBe("最初のメニュー画像を作ってみましょう！");
+  });
+
+  it("Free上限近い（セッション2/3以上）は残りセッション数を返す", () => {
+    expect(getStatsMessage(5, 2, 2)).toBe("今月の残りセッション: 1件");
+  });
+
+  it("Free上限到達（セッション3/3）は残り0件を返す", () => {
+    expect(getStatsMessage(5, 3, 3)).toBe("今月の残りセッション: 0件");
   });
 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -109,6 +109,7 @@ export default function DashboardPage() {
             onDownload={handleDownload}
             onDelete={setDeleteTarget}
             onShare={setShareTarget}
+            onCreateNew={handleCreateNew}
           />
         </div>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -19,7 +19,7 @@ import { useDashboardData, type SessionData } from "@/hooks/useDashboardData";
 import { useSessionActions } from "@/hooks/useSessionActions";
 
 export default function DashboardPage() {
-  const { sessions, setSessions, stats, setStats, galleryStats, loading, userName, onboardingCompleted, completeOnboarding, achievements, newBadges, dismissBadge } = useDashboardData();
+  const { sessions, setSessions, stats, setStats, galleryStats, loading, userName, userRole, onboardingCompleted, completeOnboarding, achievements, newBadges, dismissBadge } = useDashboardData();
   const {
     downloading,
     showLimitModal,
@@ -85,7 +85,7 @@ export default function DashboardPage() {
         <div className="absolute bottom-[15%] left-[10%] w-48 h-48 bg-accent-olive/[.04] rounded-full blur-3xl pointer-events-none" />
 
         <div className="max-w-[960px] mx-auto px-6 sm:px-10 py-10 relative z-10">
-          <DashboardHeader onCreateNew={handleCreateNew} userName={userName} stats={stats} />
+          <DashboardHeader onCreateNew={handleCreateNew} userName={userName} stats={stats} userRole={userRole} sessionCount={sessions.length} />
           <StatsSection cards={statsCards} loading={loading} />
           <QuickActions onCreateNew={handleCreateNew} />
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import GenerationDefaultsSection from "@/components/settings/GenerationDefaultsS
 import UsageSection from "@/components/settings/UsageSection";
 import DangerSection from "@/components/settings/DangerSection";
 import PrivacySection from "@/components/settings/PrivacySection";
+import NotificationSection from "@/components/settings/NotificationSection";
 
 type UserData = {
   id: string;
@@ -186,6 +187,8 @@ export default function SettingsPage() {
               <UsageSection />
 
               <SecuritySection />
+
+              <NotificationSection />
 
               <PrivacySection />
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,6 +8,7 @@ import SecuritySection from "@/components/settings/SecuritySection";
 import GenerationDefaultsSection from "@/components/settings/GenerationDefaultsSection";
 import UsageSection from "@/components/settings/UsageSection";
 import DangerSection from "@/components/settings/DangerSection";
+import PrivacySection from "@/components/settings/PrivacySection";
 
 type UserData = {
   id: string;
@@ -185,6 +186,8 @@ export default function SettingsPage() {
               <UsageSection />
 
               <SecuritySection />
+
+              <PrivacySection />
 
               <DangerSection onError={setError} />
             </div>

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -5,15 +5,20 @@ type Props = {
   onCreateNew: () => void;
   userName: string | null;
   stats: StatsData | null;
+  userRole: string | null;
+  sessionCount: number;
 };
 
-export default function DashboardHeader({ onCreateNew, userName, stats }: Props) {
+export default function DashboardHeader({ onCreateNew, userName, stats, userRole, sessionCount }: Props) {
   const greeting = getGreeting();
-  const heading = userName ? `${greeting}、${userName}さん` : greeting;
-  const subtitle = stats ? getStatsMessage(stats.monthlyImages) : "生成履歴と統計";
+  const heading = userName ? `${userName}さん、${greeting}` : greeting;
+  const isFree = userRole === "user";
+  const subtitle = stats
+    ? getStatsMessage(stats.monthlyImages, stats.recentSessions, isFree ? sessionCount : undefined)
+    : "生成履歴と統計";
 
   return (
-    <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 mb-10">
+    <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 mb-10 animate-fade-in-up">
       <div>
         <span className="inline-block text-xs font-semibold text-accent-warm uppercase tracking-[2px] mb-2">
           Dashboard

--- a/src/components/dashboard/SessionGrid.tsx
+++ b/src/components/dashboard/SessionGrid.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import type { SessionData } from "@/hooks/useDashboardData";
 import SessionCard from "./SessionCard";
 
@@ -9,6 +8,7 @@ export default function SessionGrid({
   onDownload,
   onDelete,
   onShare,
+  onCreateNew,
 }: {
   sessions: SessionData[];
   loading: boolean;
@@ -16,6 +16,7 @@ export default function SessionGrid({
   onDownload: (item: SessionData) => void;
   onDelete: (item: SessionData) => void;
   onShare?: (item: SessionData) => void;
+  onCreateNew: () => void;
 }) {
   return (
     <section>
@@ -46,39 +47,23 @@ export default function SessionGrid({
             </div>
           ))}
         </div>
-      ) : sessions.length === 0 ? (
-        /* 空状態 — リッチデザイン */
-        <div className="text-center py-20 relative">
-          {/* Decorative background */}
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-            <div className="w-48 h-48 bg-accent-warm/[.04] rounded-full blur-2xl" />
-          </div>
-
-          <div className="relative z-10">
-            {/* Emoji with decorative ring */}
-            <div className="inline-flex items-center justify-center w-24 h-24 rounded-full bg-accent-warm/[.06] border border-accent-warm/10 mb-6">
-              <span className="text-5xl">🍽</span>
-            </div>
-
-            <h3 className="font-[family-name:var(--font-playfair)] text-xl font-bold mb-2 text-text-primary">
-              まだ生成履歴がありません
-            </h3>
-            <p className="text-sm text-text-muted mb-6 max-w-[320px] mx-auto leading-relaxed">
-              AIとチャットするだけで、プロ品質のメニュー画像を作成できます
-            </p>
-            <Link
-              href="/chat"
-              className="inline-flex items-center gap-2 px-8 py-3.5 bg-accent-warm text-white rounded-full text-[15px] font-semibold no-underline transition-all duration-300 hover:bg-accent-warm-hover hover:shadow-[0_4px_20px_rgba(232,113,58,.3)] hover:-translate-y-0.5"
-            >
-              最初のメニューを作成
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-                <path d="M5 12h14M12 5l7 7-7 7" />
-              </svg>
-            </Link>
-          </div>
-        </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {/* +新規作成カード */}
+          <button
+            onClick={onCreateNew}
+            className="group flex flex-col items-center justify-center min-h-[200px] rounded-[20px] border-2 border-dashed border-border-light bg-transparent cursor-pointer transition-all duration-300 hover:border-accent-warm hover:text-accent-warm hover:-translate-y-0.5 hover:shadow-[0_4px_16px_rgba(232,113,58,.1)] animate-fade-in-up"
+          >
+            <div className="w-12 h-12 rounded-full bg-accent-warm/[.06] flex items-center justify-center mb-3 transition-colors duration-300 group-hover:bg-accent-warm/[.12]">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="text-text-secondary transition-colors duration-300 group-hover:text-accent-warm">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+            </div>
+            <span className="text-sm font-semibold text-text-secondary transition-colors duration-300 group-hover:text-accent-warm">
+              新しいメニューを作成
+            </span>
+          </button>
+
           {sessions.map((item, idx) => (
             <SessionCard
               key={item.id}

--- a/src/components/settings/NotificationSection.tsx
+++ b/src/components/settings/NotificationSection.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import SettingsCard from "./shared/SettingsCard";
+import SettingsToggle from "./shared/SettingsToggle";
+
+type NotificationSettings = {
+  new_features: boolean;
+  generation_complete: boolean;
+  gallery_reactions: boolean;
+  marketing: boolean;
+  email_frequency: string;
+};
+
+const DEFAULT_SETTINGS: NotificationSettings = {
+  new_features: true,
+  generation_complete: true,
+  gallery_reactions: true,
+  marketing: false,
+  email_frequency: "realtime",
+};
+
+const FREQUENCY_OPTIONS = [
+  { value: "realtime", label: "リアルタイム" },
+  { value: "daily", label: "日次まとめ" },
+  { value: "weekly", label: "週次まとめ" },
+  { value: "off", label: "受け取らない" },
+];
+
+export default function NotificationSection() {
+  const [settings, setSettings] = useState<NotificationSettings>(DEFAULT_SETTINGS);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function fetchSettings() {
+      try {
+        const res = await fetch("/api/account/settings");
+        if (res.ok) {
+          const data = await res.json();
+          if (data.notifications) {
+            setSettings({
+              new_features: data.notifications.new_features ?? true,
+              generation_complete: data.notifications.generation_complete ?? true,
+              gallery_reactions: data.notifications.gallery_reactions ?? true,
+              marketing: data.notifications.marketing ?? false,
+              email_frequency: data.notifications.email_frequency ?? "realtime",
+            });
+          }
+        }
+      } catch {
+        // フォールバック
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSettings();
+  }, []);
+
+  const patchNotification = useCallback(async (updates: Partial<NotificationSettings>) => {
+    const res = await fetch("/api/account/settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ notifications: updates }),
+    });
+    if (!res.ok) throw new Error("save failed");
+  }, []);
+
+  const handleToggle = useCallback(async (field: keyof NotificationSettings, value: boolean) => {
+    const prev = settings[field];
+    setSettings((s) => ({ ...s, [field]: value }));
+    setSaving(field);
+    setError("");
+
+    try {
+      await patchNotification({ [field]: value });
+    } catch {
+      setSettings((s) => ({ ...s, [field]: prev }));
+      setError("保存に失敗しました。");
+    } finally {
+      setSaving(null);
+    }
+  }, [settings, patchNotification]);
+
+  const handleFrequencyChange = useCallback(async (value: string) => {
+    const prev = settings.email_frequency;
+    setSettings((s) => ({ ...s, email_frequency: value }));
+    setSaving("email_frequency");
+    setError("");
+
+    try {
+      await patchNotification({ email_frequency: value });
+    } catch {
+      setSettings((s) => ({ ...s, email_frequency: prev }));
+      setError("保存に失敗しました。");
+    } finally {
+      setSaving(null);
+    }
+  }, [settings.email_frequency, patchNotification]);
+
+  const isOff = settings.email_frequency === "off";
+
+  if (loading) {
+    return (
+      <SettingsCard id="notifications" title="Notifications" accentColor="gold" animationDelay="0.35s">
+        <div className="space-y-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-12 bg-border-light/50 rounded-[8px] animate-pulse" />
+          ))}
+        </div>
+      </SettingsCard>
+    );
+  }
+
+  return (
+    <SettingsCard id="notifications" title="Notifications" accentColor="gold" animationDelay="0.35s">
+      {error && (
+        <div className="mb-4 p-2.5 rounded-[8px] bg-red-50 border border-red-200 text-red-600 text-xs">
+          {error}
+        </div>
+      )}
+
+      {/* メール受信頻度 */}
+      <div className="mb-5">
+        <label className="block text-sm font-medium text-text-primary mb-1.5">
+          メール受信頻度
+        </label>
+        <select
+          value={settings.email_frequency}
+          onChange={(e) => handleFrequencyChange(e.target.value)}
+          disabled={saving === "email_frequency"}
+          className="w-full px-3 py-2.5 rounded-[8px] border border-border-light bg-bg-primary text-sm text-text-primary transition-colors duration-200 focus:outline-none focus:border-accent-warm disabled:opacity-50"
+        >
+          {FREQUENCY_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+        <p className="text-xs text-text-secondary mt-1">
+          通知メールの配信タイミングを設定します
+        </p>
+      </div>
+
+      {/* トグル群 */}
+      <div className={`divide-y divide-border-light ${isOff ? "opacity-40 pointer-events-none" : ""}`}>
+        <SettingsToggle
+          label="新機能のお知らせ"
+          description="サービスアップデート情報をお届けします"
+          checked={settings.new_features}
+          onChange={(v) => handleToggle("new_features", v)}
+          disabled={saving === "new_features" || isOff}
+        />
+        <SettingsToggle
+          label="画像生成完了"
+          description="画像生成が完了した際に通知します"
+          checked={settings.generation_complete}
+          onChange={(v) => handleToggle("generation_complete", v)}
+          disabled={saving === "generation_complete" || isOff}
+        />
+        <SettingsToggle
+          label="ギャラリーの反応"
+          description="いいね・保存された時に通知します"
+          checked={settings.gallery_reactions}
+          onChange={(v) => handleToggle("gallery_reactions", v)}
+          disabled={saving === "gallery_reactions" || isOff}
+        />
+        <SettingsToggle
+          label="マーケティングメール"
+          description="キャンペーンやお得な情報をお届けします"
+          checked={settings.marketing}
+          onChange={(v) => handleToggle("marketing", v)}
+          disabled={saving === "marketing" || isOff}
+        />
+      </div>
+    </SettingsCard>
+  );
+}

--- a/src/components/settings/PrivacySection.tsx
+++ b/src/components/settings/PrivacySection.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import SettingsCard from "./shared/SettingsCard";
+import SettingsToggle from "./shared/SettingsToggle";
+
+type PrivacySettings = {
+  ai_data_usage: boolean;
+  gallery_show_shop_name: boolean;
+  analytics_data_sharing: boolean;
+};
+
+const DEFAULT_SETTINGS: PrivacySettings = {
+  ai_data_usage: true,
+  gallery_show_shop_name: true,
+  analytics_data_sharing: true,
+};
+
+export default function PrivacySection() {
+  const [settings, setSettings] = useState<PrivacySettings>(DEFAULT_SETTINGS);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function fetchSettings() {
+      try {
+        const res = await fetch("/api/account/settings");
+        if (res.ok) {
+          const data = await res.json();
+          if (data.settings) {
+            setSettings({
+              ai_data_usage: data.settings.ai_data_usage ?? true,
+              gallery_show_shop_name: data.settings.gallery_show_shop_name ?? true,
+              analytics_data_sharing: data.settings.analytics_data_sharing ?? true,
+            });
+          }
+        }
+      } catch {
+        // フォールバック
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSettings();
+  }, []);
+
+  const handleToggle = useCallback(async (field: keyof PrivacySettings, value: boolean) => {
+    const prev = settings[field];
+    setSettings((s) => ({ ...s, [field]: value }));
+    setSaving(field);
+    setError("");
+
+    try {
+      const res = await fetch("/api/account/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [field]: value }),
+      });
+
+      if (!res.ok) {
+        setSettings((s) => ({ ...s, [field]: prev }));
+        setError("保存に失敗しました。");
+      }
+    } catch {
+      setSettings((s) => ({ ...s, [field]: prev }));
+      setError("通信エラーが発生しました。");
+    } finally {
+      setSaving(null);
+    }
+  }, [settings]);
+
+  if (loading) {
+    return (
+      <SettingsCard id="privacy" title="Privacy" accentColor="olive" animationDelay="0.3s">
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-12 bg-border-light/50 rounded-[8px] animate-pulse" />
+          ))}
+        </div>
+      </SettingsCard>
+    );
+  }
+
+  return (
+    <SettingsCard id="privacy" title="Privacy" accentColor="olive" animationDelay="0.3s">
+      {error && (
+        <div className="mb-4 p-2.5 rounded-[8px] bg-red-50 border border-red-200 text-red-600 text-xs">
+          {error}
+        </div>
+      )}
+
+      <div className="divide-y divide-border-light">
+        <SettingsToggle
+          label="AI学習へのデータ提供"
+          description="アップロード画像・チャット内容をAIモデルの改善に利用します"
+          checked={settings.ai_data_usage}
+          onChange={(v) => handleToggle("ai_data_usage", v)}
+          disabled={saving === "ai_data_usage"}
+        />
+        <SettingsToggle
+          label="ギャラリー公開時の店名表示"
+          description="ギャラリーに画像を共有する際、店舗名を表示します"
+          checked={settings.gallery_show_shop_name}
+          onChange={(v) => handleToggle("gallery_show_shop_name", v)}
+          disabled={saving === "gallery_show_shop_name"}
+        />
+        <SettingsToggle
+          label="使用状況データの共有"
+          description="サービス改善のための匿名利用データを共有します"
+          checked={settings.analytics_data_sharing}
+          onChange={(v) => handleToggle("analytics_data_sharing", v)}
+          disabled={saving === "analytics_data_sharing"}
+        />
+      </div>
+    </SettingsCard>
+  );
+}

--- a/src/components/settings/SettingsSidenav.tsx
+++ b/src/components/settings/SettingsSidenav.tsx
@@ -12,6 +12,7 @@ const NAV_ITEMS: SettingsNavItem[] = [
   { id: "generation", label: "画像生成", icon: "🎨" },
   { id: "usage", label: "使用状況", icon: "📊" },
   { id: "security", label: "セキュリティ", icon: "🔒" },
+  { id: "privacy", label: "プライバシー", icon: "🛡️" },
   { id: "danger", label: "退会", icon: "⚠️" },
 ];
 

--- a/src/components/settings/SettingsSidenav.tsx
+++ b/src/components/settings/SettingsSidenav.tsx
@@ -12,6 +12,7 @@ const NAV_ITEMS: SettingsNavItem[] = [
   { id: "generation", label: "画像生成", icon: "🎨" },
   { id: "usage", label: "使用状況", icon: "📊" },
   { id: "security", label: "セキュリティ", icon: "🔒" },
+  { id: "notifications", label: "通知", icon: "🔔" },
   { id: "privacy", label: "プライバシー", icon: "🛡️" },
   { id: "danger", label: "退会", icon: "⚠️" },
 ];

--- a/src/components/settings/shared/SettingsToggle.tsx
+++ b/src/components/settings/shared/SettingsToggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+type Props = {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+};
+
+export default function SettingsToggle({ label, description, checked, onChange, disabled = false }: Props) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-3">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-text-primary">{label}</p>
+        <p className="text-xs text-text-secondary mt-0.5 leading-relaxed">{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 flex-shrink-0 rounded-full transition-colors duration-200 cursor-pointer border-none ${
+          disabled ? "opacity-50 cursor-not-allowed" : ""
+        } ${checked ? "bg-accent-warm" : "bg-border-light"}`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transform transition-transform duration-200 mt-0.5 ${
+            checked ? "translate-x-[22px]" : "translate-x-0.5"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -60,6 +60,7 @@ export function useDashboardData() {
   const [galleryStats, setGalleryStats] = useState<GalleryStatsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [userName, setUserName] = useState<string | null>(null);
+  const [userRole, setUserRole] = useState<string | null>(null);
   const [onboardingCompleted, setOnboardingCompleted] = useState<boolean | null>(null);
   const [achievements, setAchievements] = useState<AchievementData | null>(null);
   const [newBadges, setNewBadges] = useState<NewAchievement[]>([]);
@@ -81,6 +82,7 @@ export function useDashboardData() {
         if (accountRes.ok) {
           const accountData = await accountRes.json();
           setUserName(accountData.user?.name || null);
+          setUserRole(accountData.user?.role || null);
           setOnboardingCompleted(!!accountData.user?.onboarding_completed_at);
         }
         if (achieveRes.ok) {
@@ -132,5 +134,5 @@ export function useDashboardData() {
     }
   };
 
-  return { sessions, setSessions, stats, setStats, galleryStats, loading, userName, onboardingCompleted, completeOnboarding, achievements, newBadges, dismissBadge };
+  return { sessions, setSessions, stats, setStats, galleryStats, loading, userName, userRole, onboardingCompleted, completeOnboarding, achievements, newBadges, dismissBadge };
 }

--- a/src/lib/greeting.ts
+++ b/src/lib/greeting.ts
@@ -2,12 +2,16 @@ export function getGreeting(): string {
   const hour = new Date().getHours();
   if (hour >= 5 && hour < 11) return "おはようございます";
   if (hour >= 11 && hour < 17) return "こんにちは";
-  return "おつかれさまです";
+  return "こんばんは";
 }
 
-export function getStatsMessage(monthlyImages: number, recentSessions?: number): string {
+export function getStatsMessage(monthlyImages: number, recentSessions?: number, sessionCount?: number): string {
   if (recentSessions !== undefined && recentSessions === 0) {
     return "最初のメニュー画像を作ってみましょう！";
+  }
+  if (sessionCount !== undefined && sessionCount >= 2) {
+    const remaining = Math.max(0, 3 - sessionCount);
+    return `今月の残りセッション: ${remaining}件`;
   }
   if (monthlyImages === 0) return "まだ画像を生成していません。始めましょう！";
   return `今月 ${monthlyImages}枚 のメニュー画像を作成しました`;

--- a/supabase/012_create_notification_preferences.sql
+++ b/supabase/012_create_notification_preferences.sql
@@ -1,0 +1,28 @@
+-- 012: 通知設定テーブル
+-- 設定画面 通知設定 (#51) 対応
+
+CREATE TABLE IF NOT EXISTS public.notification_preferences (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL UNIQUE REFERENCES public.users(id) ON DELETE CASCADE,
+
+  -- 通知種別
+  new_features boolean NOT NULL DEFAULT true,
+  generation_complete boolean NOT NULL DEFAULT true,
+  gallery_reactions boolean NOT NULL DEFAULT true,
+  marketing boolean NOT NULL DEFAULT false,
+
+  -- メール受信頻度
+  email_frequency text NOT NULL DEFAULT 'realtime'
+    CHECK (email_frequency IN ('realtime', 'daily', 'weekly', 'off')),
+
+  -- タイムスタンプ
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_prefs_user_id ON public.notification_preferences(user_id);
+
+CREATE TRIGGER update_notification_prefs_updated_at
+  BEFORE UPDATE ON public.notification_preferences
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_updated_at();


### PR DESCRIPTION
## Summary

- **ウェルカムエリア刷新 (#37)**: 時間帯挨拶を「こんばんは」に修正、ユーザー名先行表示、Free上限近い時の残りセッション表示、fadeInUpアニメーション追加
- **+新規作成カード (#39)**: セッショングリッド先頭に破線ボーダーの新規作成カードを配置。handleCreateNew経由でプラン制限チェック付き
- **プライバシー設定 (#50)**: SettingsToggle共通コンポーネント + PrivacySection（AI学習・店名表示・使用状況データの3トグル、即時保存）
- **通知設定 (#51)**: NotificationSection（4トグル + メール頻度セレクト）、notification_preferencesテーブル追加、settings API拡張

## Changes

### ダッシュボード (Part 1)
- `src/lib/greeting.ts`: 夜間挨拶変更 + Free上限メッセージ対応
- `src/components/dashboard/DashboardHeader.tsx`: Props拡張、見出しフォーマット変更
- `src/components/dashboard/SessionGrid.tsx`: 先頭に+新規作成カード追加
- `src/hooks/useDashboardData.ts`: userRole追加
- `src/app/dashboard/page.tsx`: 新Props受け渡し

### 設定画面 (Part 2)
- `src/components/settings/shared/SettingsToggle.tsx`: 新規（共通トグル）
- `src/components/settings/PrivacySection.tsx`: 新規（3トグル）
- `src/components/settings/NotificationSection.tsx`: 新規（4トグル + 頻度セレクト）
- `src/app/api/account/settings/route.ts`: privacy + notifications対応
- `src/app/settings/page.tsx`: 2セクション追加
- `src/components/settings/SettingsSidenav.tsx`: 8項目構成に更新
- `supabase/012_create_notification_preferences.sql`: 新規

## Test plan

- [x] `npm run build` エラーなし
- [x] `npm test` 74テスト全パス（+2 greeting tests）
- [ ] ダッシュボードのウェルカムエリアに時間帯挨拶 + 状態メッセージが表示される
- [ ] セッショングリッド先頭に新規作成カードがあり、クリックでチャット画面に遷移する
- [ ] 設定画面にプライバシーセクション（トグル3つ）が表示される
- [ ] 設定画面に通知設定セクション（トグル4つ + 頻度セレクト）が表示される
- [ ] トグル変更が即時保存される
- [ ] 「受け取らない」選択時に通知トグルがグレーアウトされる

Closes #37, #39, #50, #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)